### PR TITLE
Add new attachment handler for opening attachments and viewing them in neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ You can configure several global options to tailor the plugin's behavior:
 | :----------------- | :--------------------------------------: | :------------       |
 | `notmuch_db_path`  | Directory containing the `.notmuch/` dir | `$HOME/Mail`        |
 | `maildir_sync_cmd` | Bash command to run for syncing maildir  | `mbsync -a`         |
-| `open_cmd`         | Bash command for opening attachments     | `xdg-open`          |
+| `open_handler`         | Bash command for opening attachments     | `xdg-open`          |
 | `view_handler`         | Bash command for converting attachments to text to view in vim buffer     | `view-handler`          |
 | `keymaps`          | Configure any (WIP) command's keymap     | See `config.lua`[1] |
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ the familiar Vim interface and motions.
 - 📧 **Email Browsing**: Navigate emails with Vim-like movements.
 - 🔍 **Search Your Email**: Leverage `notmuch` to search your email interactively.
 - 🔗 **Thread Viewing**: Messages are loaded with folding and threading intact.
-- 📎 **Attachment Management**: View and save attachments easily.
+- 📎 **Attachment Management**: View, open and save attachments easily.
 - ⬇️ **Offline Mail Sync**: Supports `mbsync` for efficient sync processes.
 - 🔓 **Async Search**: Large mailboxes with thousands of email? No problem.
 - 🏷️ **Tag Management**: Conveniently add, remove, or toggle email tags.
@@ -99,6 +99,7 @@ You can configure several global options to tailor the plugin's behavior:
 | `notmuch_db_path`  | Directory containing the `.notmuch/` dir | `$HOME/Mail`        |
 | `maildir_sync_cmd` | Bash command to run for syncing maildir  | `mbsync -a`         |
 | `open_cmd`         | Bash command for opening attachments     | `xdg-open`          |
+| `view_handler`         | Bash command for converting attachments to text to view in vim buffer     | `view-handler`          |
 | `keymaps`          | Configure any (WIP) command's keymap     | See `config.lua`[1] |
 
 [1]: https://github.com/yousefakbar/notmuch.nvim/blob/main/lua/notmuch/config.lua
@@ -116,6 +117,20 @@ Example in plugin manager (lazy.nvim):
         },
     },
 },
+```
+
+Example `view-handler`:  
+*make sure the `view-handler` is available in your PATH*
+
+``` sh
+#!/bin/sh
+
+case "$1" in
+  *.html ) cat "$1" | w3m -T "text/html" -dump | col ;;
+  # *.pdf ) pdftohtml "$1" - | w3m -T "text/html" -dump | col ;;
+  *.pdf ) mutool draw -F html -o - "$1" | w3m -T "text/html" -dump | col ;;
+  *) echo "Unable to convert to text!" ;;
+esac
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -94,12 +94,12 @@ Here are the core commands within Notmuch.nvim:
 
 You can configure several global options to tailor the plugin's behavior:
 
-| Option             | Description                              | Default value       |
+| Option             | Description                              | Default       |
 | :----------------- | :--------------------------------------: | :------------       |
 | `notmuch_db_path`  | Directory containing the `.notmuch/` dir | `$HOME/Mail`        |
 | `maildir_sync_cmd` | Bash command to run for syncing maildir  | `mbsync -a`         |
-| `open_handler`         | Bash command for opening attachments     | `xdg-open`          |
-| `view_handler`         | Bash command for converting attachments to text to view in vim buffer     | `view-handler`          |
+| `open_handler`         | Callback function for opening attachments     | By default runs `xdg-open`          |
+| `view_handler`         | Callback function for converting attachments to text to view in vim buffer     | By default runs `view-handler`          |
 | `keymaps`          | Configure any (WIP) command's keymap     | See `config.lua`[1] |
 
 [1]: https://github.com/yousefakbar/notmuch.nvim/blob/main/lua/notmuch/config.lua

--- a/ftplugin/notmuch-attach.vim
+++ b/ftplugin/notmuch-attach.vim
@@ -1,4 +1,5 @@
 let attach = v:lua.require('notmuch.attach')
 nmap <buffer> <silent> q :bwipeout<CR>
 nmap <buffer> <silent> s :call attach.save_attachment_part()<CR>
+nmap <buffer> <silent> o :call attach.open_attachment_part()<CR>
 nmap <buffer> <silent> v :call attach.view_attachment_part()<CR>

--- a/lua/notmuch/attach.lua
+++ b/lua/notmuch/attach.lua
@@ -16,9 +16,41 @@ local function show_github_patch(link)
 end
 
 -- TODO generalize this: <dontcare>/<extension part
-a.view_attachment_part = function()
+a.open_attachment_part = function()
   local f = a.save_attachment_part('/tmp')
   os.execute(config.options.open_cmd .. ' ' .. f)
+end
+
+a.view_attachment_part = function()
+  local f = a.save_attachment_part('/tmp')
+  -- local output = vim.fn.system({config.options.view_handler, f})
+  local output = config.options.view_handler({path = f})
+
+  local lines = u.split(output, "[^\r\n]+")
+
+  local buf = v.nvim_create_buf(true, true)
+
+
+  -- calculate the position to center the window
+  local width = math.floor(vim.o.columns * 0.8)
+  local height = math.floor(vim.o.lines * 0.8)
+  local col = math.floor((vim.o.columns - width) / 2)
+  local row = math.floor((vim.o.lines - height) / 2)
+
+  local win = vim.api.nvim_open_win(buf, true, {
+      border = "rounded",
+      relative = "editor",
+      style = "minimal",
+      height = height,
+      width = width,
+      row = row,
+      col = col,
+  })
+
+  v.nvim_buf_set_lines(buf, 0, -1, false, lines)
+
+  vim.api.nvim_set_option_value('modifiable', false, { buf = buf })
+  vim.keymap.set('n', 'q', function() vim.api.nvim_win_close(win, false) end, { buffer = buf })
 end
 
 -- TODO generalize this: <dontcare>/<extension part

--- a/lua/notmuch/attach.lua
+++ b/lua/notmuch/attach.lua
@@ -18,7 +18,8 @@ end
 -- TODO generalize this: <dontcare>/<extension part
 a.open_attachment_part = function()
   local f = a.save_attachment_part('/tmp')
-  os.execute(config.options.open_cmd .. ' ' .. f)
+  -- os.execute(config.options.open_handler .. ' ' .. f)
+  config.options.open_handler({path = f})
 end
 
 a.view_attachment_part = function()

--- a/lua/notmuch/config.lua
+++ b/lua/notmuch/config.lua
@@ -9,7 +9,9 @@ C.defaults = function()
   local defaults = {
     notmuch_db_path = os.getenv('HOME') .. '/Mail',
     maildir_sync_cmd = 'mbsync -a',
-    open_cmd = 'xdg-open',
+    open_handler = function(attachment)
+      os.execute('xdg-open ' .. attachment.path .. ' >/dev/null 2>/dev/null')
+    end,
     view_handler = function(attachment)
       return vim.fn.system({"view-handler", attachment.path})
     end,

--- a/lua/notmuch/config.lua
+++ b/lua/notmuch/config.lua
@@ -10,6 +10,9 @@ C.defaults = function()
     notmuch_db_path = os.getenv('HOME') .. '/Mail',
     maildir_sync_cmd = 'mbsync -a',
     open_cmd = 'xdg-open',
+    view_handler = function(attachment)
+      return vim.fn.system({"view-handler", attachment.path})
+    end,
     keymaps = { -- This should capture all notmuch.nvim related keymappings
       sendmail = '<C-g><C-g>',
     },


### PR DESCRIPTION
This PR adds two new attachment handlers to improve how attachments are opened and viewed:

`open_handler`: replaces the old `open_cmd` config option and is a callback function to open attachments externally. By default, it calls xdg-open, just like the old setup.

`view_handler`: a new config option which is a callback function for viewing attachments directly inside Vim. By default it runs a view-handler shell command, which you can customize.

This change makes it easier to handle attachments in different ways depending on the context, either externally or within Vim.

I included a example shell script in the readme for `view-handler`. All it needs to do is to convert the file to text.

This PR is a breaking change as it removes the old `open_cmd`!