### PR TITLE
feat(send): select msmtp account based on from header

### DIFF
--- a/lua/notmuch/send.lua
+++ b/lua/notmuch/send.lua
@@ -41,7 +41,7 @@ end
 -- @usage
 --   require('notmuch.send').sendmail('/tmp/my_new_email.eml')
 s.sendmail = function(filename)
-  os.execute('msmtp -t <' .. filename)
+  os.execute('msmtp -t --read-envelope-from <' .. filename)
   print('Successfully sent email: ' .. filename)
 end
 


### PR DESCRIPTION
With `--read-envelope-from` flag, msmtp selects the mail account based on the from header if found. If not found it falls back to the default account. This is particularly useful while using multiple mail accounts. It feels like a sane default, but there might be use-cases I am not considering.