### PR TITLE
fix(send): sanitize message id for reply filename

### DIFF
--- a/lua/notmuch/send.lua
+++ b/lua/notmuch/send.lua
@@ -217,7 +217,8 @@ s.reply = function()
   if not id then return end
 
   -- Create new draft mail to hold reply
-  local reply_filename = '/tmp/reply-' .. id .. '.eml'
+  local sanitized_id = id:gsub('/', '-')
+  local reply_filename = '/tmp/reply-' .. sanitized_id .. '.eml'
 
   -- Create and edit buffer containing reply file
   local buf = v.nvim_create_buf(true, false)


### PR DESCRIPTION
Prevent slashes in message IDs from causing invalid file paths when creating reply drafts. Replace '/' with '-' to ensure the reply filename is valid and avoids file system errors.

Solves https://github.com/yousefakbar/notmuch.nvim/issues/18