### PR TITLE
fix: use mktemp to create the compose file

### DIFF
--- a/lua/notmuch/send.lua
+++ b/lua/notmuch/send.lua
@@ -292,15 +292,7 @@ end
 --   require('notmuch.send').compose()
 s.compose = function(to)
   to = to or ''
-	local mktemp = vim.system({ 'mktemp', '-t', 'compose.XXXXXX.eml' }):wait()
-	if mktemp.code ~= 0 then
-		vim.notify(
-			'❌ Failed to create temporary file \n' .. mktemp.stderr,
-			vim.log.levels.ERROR
-		)
-		return
-	end
-	local compose_filename = vim.trim(mktemp.stdout)
+  local compose_filename = vim.fn.tempname() .. '-compose.eml'
 
   -- TODO: Add ability to modify default body message and signature
   local headers = {


### PR DESCRIPTION
It can often happen that one writes several mails at the same time, hence having several instances of NeoVim open (or simply several buffers) where you compose your mail... But all use the same `/tmp/compose.eml` file hardcoded [here](https://github.com/yousefakbar/notmuch.nvim/blob/54c579700adacf58660a75725a0e5729e2b29960/lua/notmuch/send.lua#L295). I propose using `mktemp` to create a temporary file, which could be more robust as well (it perhaps won't work on non Unix-like systems though, perhaps I should add a fallback; but assuming the existence of /tmp is already assuming something vaguely Unix-like). This way, we avoid:
- `Ignoring swap file from process XXXX` warnings
- Warning that the file has been modified elsewhere
- Accidentally overwriting one of your emails if you write another one to disk
- ...