### PR TITLE
docs: specify that path to the notmuch database must be absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ You can configure several global options to tailor the plugin's behavior:
 
 | Option             | Description                                                                     | Default                         |
 | :----------------- | :-----------------------------------------------------------------------------: | :------------------------------ |
-| `notmuch_db_path`  | Directory containing the `.notmuch/` dir                                        | `$HOME/Mail`                    |
+| `notmuch_db_path`  | Directory containing the `.notmuch/` dir (path must be absolute)                | `$HOME/Mail`                    |
 | `maildir_sync_cmd` | Bash command to run for syncing maildir                                         | `mbsync -a`                     |
 | `sync.sync_mode`   | Async mode for the `maildir_sync_cmd`                                           | `buffer`                        |
 | `keymaps`          | Configure any (WIP) command's keymap                                            | See `config.lua`[1]             |

--- a/doc/notmuch.txt
+++ b/doc/notmuch.txt
@@ -227,8 +227,8 @@ can be modified to alter the granular behavior of some notmuch commands. Each
 option will be listed with its default value.
 
 *notmuch_db_path*
-  Path to your notmuch database. More precisely, set this to the directory
-  that contains the `.notmuch` directory.
+  Absolute path to your notmuch database. More precisely, set this to the
+  directory that contains the `.notmuch` directory.
 
   Default value:
     Fetched from `notmuch` config.


### PR DESCRIPTION
After installing the plugin, I tried to use the `Notmuch` command, which failed with the error `Error opening database with err=13`. Searching for the error message in the source code, I found that it happened [here](https://github.com/yousefakbar/notmuch.nvim/blob/54c579700adacf58660a75725a0e5729e2b29960/lua/notmuch/cnotmuch.lua#L158). I looked at the notmuch man pages to better understand where this came from, and wrote the following C code
```c
#include <notmuch.h>
#include <stdio.h>

int main(void) {
  notmuch_database_t *db = NULL;

  notmuch_status_t st = notmuch_database_open(
      "~/.local/share/mail", NOTMUCH_DATABASE_MODE_READ_ONLY, &db);

  if (st != NOTMUCH_STATUS_SUCCESS) {
    fprintf(stderr, "notmuch error: %d (%s)\n", st,
            notmuch_status_to_string(st));
    return 1;
  }

  notmuch_database_destroy(db);
  return 0;
}
```
which gave me, upon running:
```
Error: Database path must be absolute.
notmuch error: 13 (Path supplied is illegal for this function)
```
Indeed, I wrote `notmuch_db_path = "~/.local/share/mail"` in my config. To avoid other people the hassle of searching what this error 13 could be, I propose explicitely writing in the docs that the path to the database must be absolute. Another possibility would be to replace the tilde ourselves before passing it to notmuch, or we can let the user replace it with `vim.env.HOME`.