### PR TITLE
fix(send): use tempname for creating temporary reply file

### DIFF
--- a/lua/notmuch/send.lua
+++ b/lua/notmuch/send.lua
@@ -218,7 +218,7 @@ s.reply = function()
 
   -- Create new draft mail to hold reply
   local sanitized_id = id:gsub('/', '-')
-  local reply_filename = '/tmp/reply-' .. sanitized_id .. '.eml'
+  local reply_filename = vim.fn.tempname() .. '-reply-' .. sanitized_id .. '.eml'
 
   -- Create and edit buffer containing reply file
   local buf = v.nvim_create_buf(true, false)


### PR DESCRIPTION
Following up https://github.com/yousefakbar/notmuch.nvim/pull/22, I noticed the usage of a single filename in `/tmp` [here](https://github.com/yousefakbar/notmuch.nvim/blob/8d510adeba03020d90b3450c8abcf59c963d88c9/lua/notmuch/send.lua#L221) as well. This commit simply replaces `/tmp` with `vim.fn.tempname()`, like it was done for composing a new mail, for the same portability and robustness reasons as mentioned in https://github.com/yousefakbar/notmuch.nvim/pull/22.