### PR TITLE
feat: migrate to newer notmuch_database_open_with_config

### DIFF
--- a/lua/notmuch/cnotmuch.lua
+++ b/lua/notmuch/cnotmuch.lua
@@ -373,7 +373,7 @@ end
 local function detect_notmuch_api()
   local obj = vim.system(({ "notmuch", "--version" })):wait()
   assert(obj.code == 0, 'Error getting notmuch version: ' .. obj.stderr)
-  has_new_api = check_notmuch_version(obj.stdout, 0, 40)
+  has_new_api = check_notmuch_version(obj.stdout, 0, 32)
   if not has_new_api then
     vim.notify('notmuch version <0.32, DEPRECATED API used. Please consider upgrading', vim.log.levels.WARN)
   end


### PR DESCRIPTION
See https://github.com/yousefakbar/notmuch.nvim/issues/24.
notmuch_database_open is deprecated since notmuch version 0.32
Using `vim.system({ "notmuch", "--version" })` gives access to the installed notmuch version. We can then check that it is greater than or equal to 0.32 to ensure backwards compatibility with older notmuch versions is preserved.

I have only tested this on notmuch 0.39; installing a pre-0.32 version to check it then uses the old api would be a good idea.

closes #24 