### PR TITLE
feat: add ability to supply email adress to Inbox command

### DIFF
--- a/lua/notmuch/init.lua
+++ b/lua/notmuch/init.lua
@@ -31,7 +31,7 @@ nm.setup = function(opts)
   -- Set up the main entry point command :Notmuch
   vim.cmd[[command Notmuch :lua require('notmuch').notmuch_hello()]]
 	vim.api.nvim_create_user_command("Inbox", function(arg)
-		if arg.fargs ~= {} then
+		if #arg.fargs ~= 0 then
 			nm.search_terms("tag:inbox to:" .. arg.args)
 		else
 			nm.search_terms("tag:inbox")


### PR DESCRIPTION
It happens quite often that I want to look at my inbox, but only for specific email addresses. It can easily be done using `NmSearch`, but I think it could be more convenient to add the ability to supply an email address or a name to the `Inbox` command, that will restrict the search to emails sent to this address. What do you think ?