### PR TITLE
feat(handlers): use vim.ui.open if available

### DIFF
--- a/lua/notmuch/config.lua
+++ b/lua/notmuch/config.lua
@@ -65,11 +65,7 @@ C.defaults = function()
       auto_open_attachment_window = false,
     },
     open_handler = function(attachment)
-			if vim.fn.has("nvim-0.10") == 1 then
-				vim.ui.open(attachment.path)
-			else
-				require('notmuch.handlers').default_open_handler(attachment)
-			end
+      require('notmuch.handlers').default_open_handler(attachment)
     end,
     view_handler = function(attachment)
       return require('notmuch.handlers').default_view_handler(attachment)

--- a/lua/notmuch/config.lua
+++ b/lua/notmuch/config.lua
@@ -66,7 +66,11 @@ C.defaults = function()
       auto_open_attachment_window = false,
     },
     open_handler = function(attachment)
-      require('notmuch.handlers').default_open_handler(attachment)
+			if vim.fn.has("nvim-0.10") == 1 then
+				vim.ui.open(attachment.path)
+			else
+				require('notmuch.handlers').default_open_handler(attachment)
+			end
     end,
     view_handler = function(attachment)
       return require('notmuch.handlers').default_view_handler(attachment)

--- a/lua/notmuch/config.lua
+++ b/lua/notmuch/config.lua
@@ -47,7 +47,6 @@ C.defaults = function()
     notmuch_db_path = db_path,
     from = name .. ' <' .. email .. '>',
     maildir_sync_cmd = 'mbsync -a',
-    open_cmd = 'xdg-open',
     logfile = nil,
     sync = {
       sync_mode = "buffer",  -- "background" | "buffer" | "terminal"

--- a/lua/notmuch/handlers.lua
+++ b/lua/notmuch/handlers.lua
@@ -5,6 +5,15 @@ local H = {}
 H.default_open_handler = function(attachment)
   local path = attachment.path
 
+  -- If `nvim` version >=0.10.0, use `vim.ui.open()`
+  if vim.ui and vim.ui.open then
+    local _, err = vim.ui.open(path)
+    if err then
+      vim.notify('notmuch.nvim: failed to open attachment: ' .. tostring(err), vim.log.levels.ERROR)
+    end
+    return
+  end
+
   -- Detect OS and choose appropriate command
   local open_cmd
   local sysname = vim.uv.os_uname()
@@ -20,7 +29,10 @@ H.default_open_handler = function(attachment)
   end
 
   -- Execute
-  vim.system({ open_cmd, path }, { detach = true })
+  local ok, err = pcall(vim.system, { open_cmd, path }, { detach = true })
+  if not ok then
+    vim.notify('notmuch.nvim: failed to open attachment: ' .. tostring(err), vim.log.levels.ERROR)
+  end
 end
 
 --- Default handler for viewing attachments in the floating window viewer

--- a/tests/specs/handlers_spec.lua
+++ b/tests/specs/handlers_spec.lua
@@ -36,12 +36,57 @@ end
 
 return {
   {
-    name = "handlers.default_open_handler invokes OS opener detached",
+    name = "handlers.default_open_handler uses vim.ui.open when available",
     run = function()
       local handlers = require("notmuch.handlers")
+      local old_open = vim.ui.open
+      local opened
+
+      vim.ui.open = function(path)
+        opened = path
+        return { wait = function() return { code = 0 } end }, nil
+      end
+
+      handlers.default_open_handler({ path = "/tmp/file.txt" })
+
+      H.eq("/tmp/file.txt", opened)
+      vim.ui.open = old_open
+    end,
+  },
+  {
+    name = "handlers.default_open_handler reports vim.ui.open failures",
+    run = function()
+      local handlers = require("notmuch.handlers")
+      local old_open = vim.ui.open
+      local old_notify = vim.notify
+      local note
+
+      vim.ui.open = function()
+        return nil, "no opener found"
+      end
+      vim.notify = function(msg, level)
+        note = { msg = msg, level = level }
+      end
+
+      handlers.default_open_handler({ path = "/tmp/file.txt" })
+
+      H.contains(note.msg, "failed to open attachment")
+      H.contains(note.msg, "no opener found")
+      H.eq(vim.log.levels.ERROR, note.level)
+
+      vim.ui.open = old_open
+      vim.notify = old_notify
+    end,
+  },
+  {
+    name = "handlers.default_open_handler falls back to OS opener without vim.ui.open",
+    run = function()
+      local handlers = require("notmuch.handlers")
+      local old_open = vim.ui.open
       local old_system = vim.system
       local captured_cmd, captured_opts
 
+      vim.ui.open = nil
       vim.system = function(cmd, opts)
         captured_cmd = cmd
         captured_opts = opts
@@ -59,6 +104,7 @@ return {
       H.same({ expected, "/tmp/file.txt" }, captured_cmd)
       H.same({ detach = true }, captured_opts)
 
+      vim.ui.open = old_open
       vim.system = old_system
     end,
   },


### PR DESCRIPTION
Starting with my smallest changes, in Nvim 0.10 `vim.ui.open` as added, which according to the docs:
```
Opens `path` with the system default handler (macOS `open`, Windows
`explorer.exe`, Linux `xdg-open`, …), or returns (but does not show) an
error message on failure.
```
which is exactly what the default open handler was doing. I kept it since I'd assume you want to keep backwards compatibility with older neovim versions, but I think it's better to use the built-in way when available.

Tested to work on my Linux laptop.