### PR TITLE
fix: use vim.uv instead of vim.loop

### DIFF
--- a/doc/notmuch.txt
+++ b/doc/notmuch.txt
@@ -739,7 +739,7 @@ plugin's project codebase.
     - Pure Lua implementation for portability.
 
   - **async.lua**:
-    - Provides non-blocking subprocess execution via vim.loop.spawn().
+    - Provides non-blocking subprocess execution via vim.uv.spawn().
     - Used for asynchronous operations like searching and syncing.
     - Ensures the UI remains responsive during long-running operations.
     - Streams results incrementally as they become available.

--- a/lua/notmuch/async.lua
+++ b/lua/notmuch/async.lua
@@ -2,7 +2,7 @@ local a = {}
 
 -- Runs `notmuch search` asynchronously
 --
--- This function leverages the `vim.loop` library to spawn a subprocess and
+-- This function leverages the `vim.uv` library to spawn a subprocess and
 -- asynchronously run the `notmuch` search query in the background so it does
 -- not block `nvim`s event loop and allow seamless UX while results flow in
 --
@@ -17,12 +17,12 @@ local a = {}
 -- end)
 a.run_notmuch_search = function(search, buf, on_complete)
   -- Set up pipes for stdout and stderr to capture command output
-  local stdout = vim.loop.new_pipe(false)
-  local stderr = vim.loop.new_pipe(false)
+  local stdout = vim.uv.new_pipe(false)
+  local stderr = vim.uv.new_pipe(false)
 
-  -- Spawn subprocess using vim.loop (deprecated?)
+  -- Spawn subprocess using vim.uv
   local handle
-  handle = vim.loop.spawn("notmuch", {
+  handle = vim.uv.spawn("notmuch", {
     args = {"search", search},
     stdio = {nil, stdout, stderr}
   }, vim.schedule_wrap(function()
@@ -39,7 +39,7 @@ a.run_notmuch_search = function(search, buf, on_complete)
   local partial_data = ""
 
   -- Read data from stdout and write it to the buffer
-  vim.loop.read_start(stdout, vim.schedule_wrap(function(_, data)
+  vim.uv.read_start(stdout, vim.schedule_wrap(function(_, data)
     if data then
       -- Combine earlier incomplete chunk with newest read
       partial_data = partial_data .. data
@@ -62,7 +62,7 @@ a.run_notmuch_search = function(search, buf, on_complete)
   end))
 
   -- Log errors from stderr
-  vim.loop.read_start(stderr, vim.schedule_wrap(function(err, data)
+  vim.uv.read_start(stderr, vim.schedule_wrap(function(err, data)
     if err then
       vim.notify("ERROR: " .. err)
     elseif data then

--- a/lua/notmuch/config.lua
+++ b/lua/notmuch/config.lua
@@ -60,7 +60,11 @@ C.defaults = function()
     render_html_body = false, -- True means prioritize displaying rendered HTML
     thread_view_mode = "threaded", -- "threaded" | "newest-first" | "oldest-first" - Thread view display mode
     open_handler = function(attachment)
-      require('notmuch.handlers').default_open_handler(attachment)
+			if vim.fn.has("nvim-0.10") == 1 then
+				vim.ui.open(attachment.path)
+			else
+				require('notmuch.handlers').default_open_handler(attachment)
+			end
     end,
     view_handler = function(attachment)
       return require('notmuch.handlers').default_view_handler(attachment)

--- a/lua/notmuch/send.lua
+++ b/lua/notmuch/send.lua
@@ -176,7 +176,7 @@ end
 -- @usage
 --   require('notmuch.send').sendmail('/tmp/my_new_email.eml')
 s.sendmail = function(filename)
-  if not vim.loop.fs_stat(filename) then
+  if not vim.uv.fs_stat(filename) then
     vim.notify('❌ Email file not found: ' .. filename, vim.log.levels.ERROR)
     return false
   end

--- a/lua/notmuch/util.lua
+++ b/lua/notmuch/util.lua
@@ -71,8 +71,8 @@ u.validate_attachment_file = function(path)
 
   file:close()
 
-  -- Use vim.loop to check if it's a regular file (not directory/special file)
-  local stat = vim.loop.fs_stat(path)
+  -- Use vim.uv to check if it's a regular file (not directory/special file)
+  local stat = vim.uv.fs_stat(path)
   if not stat then
     return false, "Unable to read file metadata"
   end

--- a/tests/specs/async_spec.lua
+++ b/tests/specs/async_spec.lua
@@ -1,9 +1,9 @@
 local H = dofile("tests/helpers.lua")
 
 local function with_mocked_loop(run)
-  local old_new_pipe = vim.loop.new_pipe
-  local old_spawn = vim.loop.spawn
-  local old_read_start = vim.loop.read_start
+  local old_new_pipe = vim.uv.new_pipe
+  local old_spawn = vim.uv.spawn
+  local old_read_start = vim.uv.read_start
 
   local state = {
     pipes = {},
@@ -13,7 +13,7 @@ local function with_mocked_loop(run)
     closed_handle = false,
   }
 
-  vim.loop.new_pipe = function()
+  vim.uv.new_pipe = function()
     local pipe = {
       closed = false,
       close = function(self) self.closed = true end,
@@ -22,7 +22,7 @@ local function with_mocked_loop(run)
     return pipe
   end
 
-  vim.loop.spawn = function(cmd, opts, on_exit)
+  vim.uv.spawn = function(cmd, opts, on_exit)
     state.spawned = { cmd = cmd, opts = opts, on_exit = on_exit }
     local handle = {
       close = function() state.closed_handle = true end,
@@ -32,15 +32,15 @@ local function with_mocked_loop(run)
     return handle
   end
 
-  vim.loop.read_start = function(pipe, cb)
+  vim.uv.read_start = function(pipe, cb)
     state.reads[pipe] = cb
   end
 
   local ok, err = pcall(run, state)
 
-  vim.loop.new_pipe = old_new_pipe
-  vim.loop.spawn = old_spawn
-  vim.loop.read_start = old_read_start
+  vim.uv.new_pipe = old_new_pipe
+  vim.uv.spawn = old_spawn
+  vim.uv.read_start = old_read_start
 
   if not ok then error(err, 0) end
 end

--- a/tests/specs/ui_spec.lua
+++ b/tests/specs/ui_spec.lua
@@ -193,7 +193,7 @@ return {
         local dir = H.tmpdir()
         local saved = attach.save_attachment_part(dir, false)
         H.ok(saved and saved:find(dir, 1, true), "expected save path in temp dir")
-        H.eq(true, vim.loop.fs_stat(saved) ~= nil)
+        H.eq(true, vim.uv.fs_stat(saved) ~= nil)
 
         vim.api.nvim_win_set_cursor(0, { 4, 0 })
         attach.open_attachment_part()


### PR DESCRIPTION
`vim.loop` is deprecated and is scheduled for deletion in Nvim 0.1. We should use the luv-based `vim.uv` replacement instead.