### PR TITLE
feat: add send.terminal config option

### DIFF
--- a/doc/notmuch.txt
+++ b/doc/notmuch.txt
@@ -259,6 +259,12 @@ option will be listed with its default value.
   Default value:
     `mbsync -a`
 
+*send.terminal*
+  Wether to open a terminal when using msmtp to send a mail. Useful if you need
+  to input a password for instance.
+
+  Defaults to `true`
+
 *sync.sync_mode*
   Controls how the mail synchronization is displayed and managed. This option
   accepts the following values:

--- a/lua/notmuch/config.lua
+++ b/lua/notmuch/config.lua
@@ -49,6 +49,9 @@ C.defaults = function()
     maildir_sync_cmd = 'mbsync -a',
     open_cmd = 'xdg-open',
     logfile = nil,
+    send = {
+      terminal = true,
+    },
     sync = {
       sync_mode = "buffer",  -- "background" | "buffer" | "terminal"
       --   background: Silent sync in background, notifications only

--- a/lua/notmuch/send.lua
+++ b/lua/notmuch/send.lua
@@ -186,46 +186,57 @@ s.sendmail = function(filename)
   if config.options.logfile then
     table.insert(cmd_parts, '--logfile=' .. vim.fn.shellescape(config.options.logfile))
   end
-  local msmtp_cmd = table.concat(cmd_parts, ' ') .. ' <' .. vim.fn.shellescape(filename)
+
 
   vim.notify('📤 Sending email via msmtp...', vim.log.levels.INFO)
 
-  -- Open blank terminal first (reliable PTY handling for interactive input)
-  vim.cmd('botright 15split | terminal')
-  local term_buf = v.nvim_get_current_buf()
-  local term_job = vim.b.terminal_job_id
+  if config.options.send.terminal then
+    local msmtp_cmd = table.concat(cmd_parts, ' ') .. ' <' .. vim.fn.shellescape(filename)
+    -- Open blank terminal first (reliable PTY handling for interactive input)
+    vim.cmd('botright 15split | terminal')
+    local term_buf = v.nvim_get_current_buf()
+    local term_job = vim.b.terminal_job_id
 
-  -- Set up TermClose autocmd BEFORE sending command to avoid race condition
-  -- Note: Using pattern='*' instead of buffer=term_buf due to Neovim bug where
-  -- buffer-specific TermClose doesn't fire reliably on terminal buffers
-  local aug = v.nvim_create_augroup('NotmuchSendmail_' .. term_buf, { clear = true })
-  v.nvim_create_autocmd('TermClose', {
-    group = aug,
-    pattern = '*',
-    once = true,
-    callback = function(ev)
-      -- Only process TermClose for our specific terminal buffer
-      if ev.buf ~= term_buf then
-        return
+    -- Set up TermClose autocmd BEFORE sending command to avoid race condition
+    -- Note: Using pattern='*' instead of buffer=term_buf due to Neovim bug where
+    -- buffer-specific TermClose doesn't fire reliably on terminal buffers
+    local aug = v.nvim_create_augroup('NotmuchSendmail_' .. term_buf, { clear = true })
+    v.nvim_create_autocmd('TermClose', {
+      group = aug,
+      pattern = '*',
+      once = true,
+      callback = function(ev)
+        -- Only process TermClose for our specific terminal buffer
+        if ev.buf ~= term_buf then
+          return
+        end
+
+        -- Get exit code from v:event.status
+        local exit_code = vim.v.event.status or -1
+
+        -- Defer notification on success because of buffer close redraw
+        if exit_code == 0 then
+          vim.defer_fn(function() vim.notify('✅ Email sent successfully', vim.log.levels.INFO) end, 500)
+        else
+          vim.notify('❌ Failed to send email (exit code: ' .. exit_code .. ')', vim.log.levels.ERROR)
+        end
       end
+    })
 
-      -- Get exit code from v:event.status
-      local exit_code = vim.v.event.status or -1
+    -- Send the command to the terminal, then exit shell to trigger TermClose
+    vim.fn.chansend(term_job, msmtp_cmd .. ' ; exit\n')
 
-      -- Defer notification on success because of buffer close redraw
-      if exit_code == 0 then
-        vim.defer_fn(function() vim.notify('✅ Email sent successfully', vim.log.levels.INFO) end, 500)
+    -- Start in insert mode for immediate interaction (e.g. passphrase prompt)
+    vim.cmd('startinsert')
+  else
+    vim.system(cmd_parts, { stdin = u.loadfile(filename) }, function(obj)
+      if obj.code == 0 then
+        vim.notify("✅ Email sent successfully", vim.log.levels.INFO)
       else
-        vim.notify('❌ Failed to send email (exit code: ' .. exit_code .. ')', vim.log.levels.ERROR)
+        vim.notify("❌ Failed to send email: " .. vim.log.levels.ERROR)
       end
-    end
-  })
-
-  -- Send the command to the terminal, then exit shell to trigger TermClose
-  vim.fn.chansend(term_job, msmtp_cmd .. ' ; exit\n')
-
-  -- Start in insert mode for immediate interaction (e.g. passphrase prompt)
-  vim.cmd('startinsert')
+    end)
+  end
 
   return true
 end

--- a/lua/notmuch/send.lua
+++ b/lua/notmuch/send.lua
@@ -171,7 +171,7 @@ end
 --
 -- @param filename string: path to the email message you would like to send
 --
--- @return string: The log message provided by `msmtp`
+-- @return boolean: whether the mail was sent or not
 --
 -- @usage
 --   require('notmuch.send').sendmail('/tmp/my_new_email.eml')

--- a/lua/notmuch/util.lua
+++ b/lua/notmuch/util.lua
@@ -252,6 +252,17 @@ u.find_cursor_msg_id = function()
   return nil
 end
 
+---@param path string path to file to load
+---@return string? content file contents
+function u.loadfile(path)
+  local fd = vim.uv.fs_open(path, "r", 438)
+  if not fd then return end
+  local stat = vim.uv.fs_fstat(fd)
+  local content = stat and vim.uv.fs_read(fd, stat.size, 0) or nil
+  vim.uv.fs_close(fd)
+  return content
+end
+
 return u
 
 -- vim: tabstop=2:shiftwidth=2:expandtab:foldmethod=indent


### PR DESCRIPTION
By default, a terminal is created and `chansend` is used to send emails, which is useful if one needs to type a password for instance. However, this may not be the case of everyone, in which case having a terminal suddenly pop in and out of existence can be unwanted or distracting. I thus added a config option which controls that: if set to true, it simply uses `vim.system` to achieve the same thing in a much simpler way that is also more robust since it does not rely on shell escape.

Don't know whether the default should be true or false, but since setting it to false would be a breaking change, I kept the current behavior by default.