### PR TITLE
feat: jump to first message in nm.show_thread and open it if it is the only one

### DIFF
--- a/ftplugin/mail.lua
+++ b/ftplugin/mail.lua
@@ -4,6 +4,13 @@ if vim.startswith(vim.fs.basename(vim.api.nvim_buf_get_name(0)), "thread:") then
   vim.opt_local.foldmethod = "marker"
   vim.opt_local.foldlevel = 0
 
+	-- if there is only one message, open it
+  if vim.b.notmuch_messages and #vim.b.notmuch_messages == 1 then
+    vim.schedule(function()
+      vim.cmd.normal({ args = { "zR" }, bang = true })
+    end)
+  end
+
   vim.api.nvim_buf_create_user_command(0, "TagAdd", function(arg)
     tag.msg_add_tag(arg.args)
   end, {

--- a/lua/notmuch/init.lua
+++ b/lua/notmuch/init.lua
@@ -221,8 +221,9 @@ nm.show_thread = function(s)
   v.nvim_buf_set_lines(buf, 0, 0, false, { hint_text, "" })
 
   -- Place cursor at head of buffer and prepare display and disable modification
-  v.nvim_buf_set_lines(buf, -2, -1, true, {})
-  v.nvim_win_set_cursor(0, { 1, 0})
+  v.nvim_buf_set_lines(buf, -2, -1, true, {}) -- remove last line from buffer
+  v.nvim_win_set_cursor(0, { 4, 0 }) -- jump to first thread
+	-- set buffer options
   vim.bo.filetype="mail"
   vim.bo.modifiable = false
 


### PR DESCRIPTION
Each time I open a thread, I have to scroll down to the first thread to press Enter and open it. I think it would be a better behavior to position the cursor on the first thread already, so the user only has to press a single key (enter) to view it (and two, `G` and `Enter`, to view the last message).