### PR TITLE
feat: use vim.ui.select instead of vim.fn.confirm

### DIFF
--- a/lua/notmuch/delete.lua
+++ b/lua/notmuch/delete.lua
@@ -1,31 +1,38 @@
 local d = {}
-local v = vim.api
 local nm = require("notmuch")
 local r = require("notmuch.refresh")
 
-local confirm_purge = function()
-	-- remove keymap
-	vim.keymap.del("n", "DD", { buffer = true })
-	-- Confirm
-	local choice = v.nvim_call_function("confirm", {
-		"Purge deleted emails?",
-		"&Yes\n&No",
-		2, -- Default to no
-	})
+local function purge_deleted()
+  -- Confirm
+  vim.ui.select({ "Yes", "No" }, { prompt = "Purge deleted emails ?" }, function(choice)
+    if choice == "Yes" then
+      -- remove keymap
+      vim.keymap.del("n", "DD", { buffer = true })
 
-	if choice == 1 then
-		v.nvim_command("silent ! notmuch search --output=files --format=text0 tag:del and tag:/./ | xargs -0 rm")
-		v.nvim_command("silent ! notmuch new")
-		r.refresh_search_buffer()
-	end
+      -- search for mails to purge
+      vim.system(
+        { "notmuch", "search", "--output=files", "--format=text0", "tag:del", "and", "tag:/./" },
+        function(obj)
+          -- purge deleted mails
+          for _, file in ipairs(vim.split(obj.stdout, "\0", { plain = true })) do
+            vim.uv.fs_unlink(file)
+          end
+          -- reindex mails
+          vim.system({ "notmuch", "new" }, vim.schedule_wrap(
+            r.refresh_search_buffer
+          ))
+        end
+      )
+    end
+  end)
 end
 
 d.purge_del = function()
-	nm.search_terms("tag:del and tag:/./")
-	-- Set keymap for purgin
-	vim.keymap.set("n", "DD", function()
-		confirm_purge()
-	end, { buffer = true })
+  nm.search_terms("tag:del and tag:/./")
+  -- Set keymap for purgin
+  vim.keymap.set("n", "DD", function()
+    purge_deleted()
+  end, { buffer = true })
 end
 
 return d

--- a/lua/notmuch/send.lua
+++ b/lua/notmuch/send.lua
@@ -6,31 +6,18 @@ local v = vim.api
 
 local config = require('notmuch.config')
 
--- Prompt confirmation for sending an email
---
--- This function utilizes vim's builtin `confirm()` to prompt the user and
--- confirm the action of sending an email. This is applicable for sending newly
--- composed mails or replies by passing the mail file path.
---
--- @param filename string: path to the email message you would like to send
---
--- @usage
---   -- See reply() or compose()
---   vim.keymap.set('n', '<C-c><C-c>', function()
---     confirm_sendmail(reply_filename)
---   end, { buffer = true })
-local confirm_sendmail = function()
-  local choice = v.nvim_call_function('confirm', {
-    'Send email?',
-    '&Yes\n&No',
-    2 -- Default to no
-  })
-
-  if choice == 1 then
-    return true
-  else
-    return false
-  end
+---Prompt confirmation for sending an email
+---
+---This function utilizes vim.ui.select to prompt the user and
+---confirm the action of sending an email. This is applicable for sending newly
+---composed mails or replies by passing the mail file path.
+---@param cb function callback if user confirms
+local function confirm_sendmail(cb)
+	vim.ui.select({ "Yes", "No" }, { prompt = "Send mail ?" }, function(choice)
+		if choice == "Yes" then
+			cb()
+		end
+	end)
 end
 
 --- Builds plain text msg from contents into single-part MIME message of main
@@ -294,7 +281,7 @@ s.reply = function()
 
   -- Set keymap for sending
   vim.keymap.set('n', config.options.keymaps.sendmail, function()
-    if confirm_sendmail() then
+		confirm_sendmail(function()
       local attachments = v.nvim_buf_get_var(buf, 'notmuch_attachments')
 
       if #attachments == 0 then
@@ -304,7 +291,7 @@ s.reply = function()
       end
 
       s.sendmail(reply_filename)
-    end
+		end)
   end, { buffer = true })
 end
 
@@ -354,7 +341,7 @@ s.compose = function(to)
 
   -- Keymap for sending the email
   vim.keymap.set('n', config.options.keymaps.sendmail, function()
-    if confirm_sendmail() then
+    confirm_sendmail(function()
       if u.empty_attachment_window(buf_attach) then
         build_plain_msg(buf)
       else
@@ -362,7 +349,7 @@ s.compose = function(to)
       end
 
       s.sendmail(compose_filename)
-    end
+    end)
   end, { buffer = true })
 end
 


### PR DESCRIPTION
I replaced the existing purge function in `delete.lua` to use modern nvim features, with `vim.system` instead of `silent !`, `vim.uv.fs_unlink` instead of `xargs -0 rm`, and `vim.ui.select` instead of `vim.fn.confirm`.

I think we should use `vim.ui.select` instead of the older `vim.fn.confirm` in the other places were it is used as well; this has the benefit of working asynchrously, and avoiding ugly prompts: `vim.ui.select` is overriden by picker plugins like telescope.nvim or snacks.nvim among others.

So I think we should change it in `send.lua` too, which I added a commit for, though the corresponding tests would need to be updated for this one.

These changes were relatively straightforward, so let me know if you're okay with merging them before I also refactor `attach.save_attachment_part` and its callers, which would need a slightly larger refactoring this time since we would then have to use callbacks in the function calling it (but that shouldn't change much either, I don't think it will make the code more complex or harder to read).