### PR TITLE
fix lua annotations

### DIFF
--- a/lua/notmuch/async.lua
+++ b/lua/notmuch/async.lua
@@ -6,11 +6,11 @@ local a = {}
 -- asynchronously run the `notmuch` search query in the background so it does
 -- not block `nvim`s event loop and allow seamless UX while results flow in
 --
--- @param search string: search term to query. see `notmuch-search-terms(7)`
--- @param buf int: refers to the buffer id to write the output to
--- @param on_complete func: callback function to execute once process completes
+---@param search string: search term to query. see `notmuch-search-terms(7)`
+---@param buf int: refers to the buffer id to write the output to
+---@param on_complete func: callback function to execute once process completes
 --
--- @usage
+---@usage
 -- -- Refer to `init.lua` for example invocation
 -- require('notmuch.async').run_notmuch_search('tag:inbox', 0, function()
 --   print('Notmuch search process completed.')

--- a/lua/notmuch/cnotmuch.lua
+++ b/lua/notmuch/cnotmuch.lua
@@ -182,8 +182,8 @@ local has_new_api = false
 
 -- Opens a Notmuch database. Entry point into the api.
 --
--- @path: Directory where the Notmuch database is stored.
--- @mode: Read/write mode. Either 0 for read or 1 for read/write.
+---@path: Directory where the Notmuch database is stored.
+---@mode: Read/write mode. Either 0 for read or 1 for read/write.
 local function open_database(path, mode)
   local db = ffi.new('notmuch_database_t*[1]')
   local res
@@ -207,8 +207,8 @@ end
 
 -- Creates a query object given a search string.
 --
--- @query_string: String given by user to search the database.
--- @db: User's Notmuch database object
+---@query_string: String given by user to search the database.
+---@db: User's Notmuch database object
 function create_query(query_string, db)
   local query = nm.notmuch_query_create(db, query_string)
   return {
@@ -222,7 +222,7 @@ end
 
 -- Returns a table of all tags found in the given database
 --
--- @db: User's Notmuch database object.
+---@db: User's Notmuch database object.
 function get_all_tags(db)
   local out = {}
   local tags = nm.notmuch_database_get_all_tags(db)
@@ -279,7 +279,7 @@ end
 
 -- Return a list of thread objects from a given query.
 --
--- @query: Query object to get threads from
+---@query: Query object to get threads from
 function get_threads(query)
   local out = {}
   local threads = ffi.new('notmuch_threads_t*[1]')
@@ -355,7 +355,7 @@ end
 
 -- Counts the number of unique threads that matched a given query.
 --
--- @query: Query object from `create_query()`
+---@query: Query object from `create_query()`
 function count_threads(query)
   local count = ffi.new("unsigned int[1]")
   local res = nm.notmuch_query_count_threads(query, count)

--- a/lua/notmuch/cnotmuch.lua
+++ b/lua/notmuch/cnotmuch.lua
@@ -160,9 +160,9 @@ ffi.cdef[[
 ]]
 
 -- checks wether the current Notmuch version is greater or equal to the one provided
----@version_str should be the output of 'notmuch --version'
----@req_major the minimum major version required
----@req_minor the minimum minor versino required
+---@param version_str string: should be the output of 'notmuch --version'
+---@param req_major  integer: the minimum major version required
+---@param req_minor  integer: the minimum minor versino required
 local function check_notmuch_version(version_str, req_major, req_minor)
   local major, minor = version_str:match("(%d+)%.?(%d*)")
   major = tonumber(major) or 0
@@ -182,8 +182,8 @@ local has_new_api = false
 
 -- Opens a Notmuch database. Entry point into the api.
 --
----@path: Directory where the Notmuch database is stored.
----@mode: Read/write mode. Either 0 for read or 1 for read/write.
+---@param path string: Directory where the Notmuch database is stored.
+---@param mode integer: Read/write mode. Either 0 for read or 1 for read/write.
 local function open_database(path, mode)
   local db = ffi.new('notmuch_database_t*[1]')
   local res
@@ -207,8 +207,8 @@ end
 
 -- Creates a query object given a search string.
 --
----@query_string: String given by user to search the database.
----@db: User's Notmuch database object
+---@param query_string string: String given by user to search the database.
+---@param db unknown: User's Notmuch database object
 function create_query(query_string, db)
   local query = nm.notmuch_query_create(db, query_string)
   return {
@@ -222,7 +222,7 @@ end
 
 -- Returns a table of all tags found in the given database
 --
----@db: User's Notmuch database object.
+---@param db unknown: User's Notmuch database object.
 function get_all_tags(db)
   local out = {}
   local tags = nm.notmuch_database_get_all_tags(db)
@@ -279,7 +279,7 @@ end
 
 -- Return a list of thread objects from a given query.
 --
----@query: Query object to get threads from
+---@param query unknown: Query object to get threads from
 function get_threads(query)
   local out = {}
   local threads = ffi.new('notmuch_threads_t*[1]')
@@ -355,7 +355,7 @@ end
 
 -- Counts the number of unique threads that matched a given query.
 --
----@query: Query object from `create_query()`
+---@param query unknown: Query object from `create_query()`
 function count_threads(query)
   local count = ffi.new("unsigned int[1]")
   local res = nm.notmuch_query_count_threads(query, count)

--- a/lua/notmuch/init.lua
+++ b/lua/notmuch/init.lua
@@ -9,10 +9,10 @@ local config = require('notmuch.config')
 -- command(s) and sets configuration options based on user passed arguments or
 -- default values
 --
--- @param opts table: Table of options as passed by the user with their config
+---@param opts table: Table of options as passed by the user with their config
 --                    setup
 --
--- @usage
+---@usage
 -- -- Example from inside `lazy.nvim` plugin spec configuration
 -- {
 --   config = function()
@@ -70,7 +70,7 @@ end
 --
 -- If buffer is already open from before, it will simply load it as active
 --
--- @usage
+---@usage
 -- lua require('notmuch').notmuch_hello()
 nm.notmuch_hello = function()
   local bufno = vim.fn.bufnr('Tags')
@@ -88,11 +88,11 @@ end
 -- database **asynchronously** and returns the list of thread results in a
 -- buffer for the user to browse
 --
--- @param search string: search terms matching format from
+---@param search string: search terms matching format from
 --                       `notmuch-search-terms(7)`
--- @param jumptothreadid string: jump to thread id after search
+---@param jumptothreadid string: jump to thread id after search
 --
--- @usage
+---@usage
 -- lua require('notmuch').search_terms('tag:inbox')
 nm.search_terms = function(search, jumptothreadid)
   local num_threads_found = 0
@@ -174,11 +174,11 @@ end
 -- This function fetches all the messages in the input thread's ID from the
 -- notmuch database and displays them in the mail.vim view.
 --
--- @param s string: The string to fetch the threadid from (individual line, or
+---@param s string: The string to fetch the threadid from (individual line, or
 --                  thread full form)
--- @return true|nil: `true` for successful display, nil for any error
+---@return true|nil: `true` for successful display, nil for any error
 --
--- @usage
+---@usage
 -- nm.show_thread("thread:00000000000003aa")
 -- nm.show_thread(vim.api.nvim_get_current_line())
 nm.show_thread = function(s)
@@ -235,10 +235,10 @@ end
 -- This function runs a search query in your `notmuch` database against the
 -- argument search terms and returns the number of threads which match
 --
--- @param search string: search terms matching format from
+---@param search string: search terms matching format from
 --                       `notmuch-search-terms(7)`
 --
--- @usage
+---@usage
 -- lua require('notmuch').count('tag:inbox') -- > '999'
 nm.count = function(search)
   local db = require 'notmuch.cnotmuch' (config.options.notmuch_db_path, 0)
@@ -254,7 +254,7 @@ end
 -- consists of all the tags in the `notmuch` database for the user to select or
 -- count. They can also search from here etc.
 --
--- @usage
+---@usage
 -- nm.show_all_tags() -- opens the `hello` page
 nm.show_all_tags = function()
   -- Fetch all tags available in the notmuch database
@@ -320,7 +320,7 @@ end
 -- saved/pinned entries use their stored query; plain tag lines use "tag:<name>".
 -- Header, separator, and blank lines are silently ignored.
 --
--- @usage  called by ftplugin/notmuch-hello.vim via c
+---@usage  called by ftplugin/notmuch-hello.vim via c
 nm.count_hello_line = function()
   local lnum = vim.fn.line('.')
   local query_map = vim.b.notmuch_saved_queries or {}
@@ -351,7 +351,7 @@ end
 -- actionable lines are bare tag names and are searched with "tag:<name>".
 -- Header, separator, and blank lines are silently ignored.
 --
--- @usage  called by ftplugin/notmuch-hello.vim via <CR>
+---@usage  called by ftplugin/notmuch-hello.vim via <CR>
 nm.open_hello_line = function()
   local lnum = vim.fn.line('.')
   local query_map = vim.b.notmuch_saved_queries or {}

--- a/lua/notmuch/mime.lua
+++ b/lua/notmuch/mime.lua
@@ -68,7 +68,7 @@ end
 --
 ---@param lines string: input string
 --
----@returns out table: table of key and values
+---@return out table: table of key and values
 m.get_msg_attributes = function(lines)
   local attributes = {}
   local msg = {}
@@ -147,7 +147,7 @@ m.example_mime = {
 --
 ---@param path string: input string
 --
----@returns out string: string of mime type of file given
+---@return out string: string of mime type of file given
 m.get_mime_type = function(path)
   local output = vim.fn.system({'file', '--brief', '--mime-type', path})
   return vim.fn.trim(output)
@@ -159,7 +159,7 @@ end
 --
 ---@param length int: input int
 --
----@returns out string: string of pseudo random characters
+---@return out string: string of pseudo random characters
 m.get_boundary = function(length)
   if length > 0 then
     return m.get_boundary(length - 1) .. string.char(math.random(65, 65 + 25))
@@ -175,7 +175,7 @@ end
 --
 ---@param mime_table table: input table
 --
----@returns out table: list of string
+---@return out table: list of string
 m.make_mime_msg = function(mime_table)
   local mime = {}
   if mime_table.mime then

--- a/lua/notmuch/mime.lua
+++ b/lua/notmuch/mime.lua
@@ -66,9 +66,9 @@ end
 -- (per RFC 5322), and all subsequent lines are treated as message body.
 -- Supports RFC 5322 header continuation (lines starting with whitespace).
 --
--- @param lines string: input string
+---@param lines string: input string
 --
--- @returns out table: table of key and values
+---@returns out table: table of key and values
 m.get_msg_attributes = function(lines)
   local attributes = {}
   local msg = {}
@@ -145,9 +145,9 @@ m.example_mime = {
 --
 -- This function gets the mime type of a given file
 --
--- @param path string: input string
+---@param path string: input string
 --
--- @returns out string: string of mime type of file given
+---@returns out string: string of mime type of file given
 m.get_mime_type = function(path)
   local output = vim.fn.system({'file', '--brief', '--mime-type', path})
   return vim.fn.trim(output)
@@ -157,9 +157,9 @@ end
 --
 -- This function generates a pseudo random character string of given lenth
 --
--- @param length int: input int
+---@param length int: input int
 --
--- @returns out string: string of pseudo random characters
+---@returns out string: string of pseudo random characters
 m.get_boundary = function(length)
   if length > 0 then
     return m.get_boundary(length - 1) .. string.char(math.random(65, 65 + 25))
@@ -173,9 +173,9 @@ end
 --
 -- This function returns a mime compatible message with parameters given by the mime_table
 --
--- @param mime_table table: input table
+---@param mime_table table: input table
 --
--- @returns out table: list of string
+---@returns out table: list of string
 m.make_mime_msg = function(mime_table)
   local mime = {}
   if mime_table.mime then

--- a/lua/notmuch/refresh.lua
+++ b/lua/notmuch/refresh.lua
@@ -8,7 +8,7 @@ local nm = require('notmuch')
 -- threads) by deleting the original buffer and re-invokes the `search_terms()`
 -- function.
 --
--- @usage
+---@usage
 -- -- Normally invoked by pressing `r` in the search results buffer
 -- lua require('notmuch.refresh').refresh_search_buffer()
 r.refresh_search_buffer = function()
@@ -26,7 +26,7 @@ end
 -- messages inside by deleting the original buffer and re-invokes the
 -- `show_thread()` function again to refresh the thread view.
 --
--- @usage
+---@usage
 -- -- Normally invoked by pressing `r` in the thread view buffer
 -- lua require('notmuch.refresh').refresh_thread_buffer()
 r.refresh_thread_buffer = function()
@@ -42,7 +42,7 @@ end
 -- `show_all_tags()` function again. This is useful when you know changes have
 -- been made to the buffer contents and want to reflect it accordingly
 --
--- @usage
+---@usage
 -- -- Normally invoked by pressing `r` in the Tags buffer
 -- lua require('notmuch.refresh').refresh_hello_buffer()
 r.refresh_hello_buffer = function()

--- a/lua/notmuch/send.lua
+++ b/lua/notmuch/send.lua
@@ -12,9 +12,9 @@ local config = require('notmuch.config')
 -- confirm the action of sending an email. This is applicable for sending newly
 -- composed mails or replies by passing the mail file path.
 --
--- @param filename string: path to the email message you would like to send
+---@param filename string: path to the email message you would like to send
 --
--- @usage
+---@usage
 --   -- See reply() or compose()
 --   vim.keymap.set('n', '<C-c><C-c>', function()
 --     confirm_sendmail(reply_filename)
@@ -169,11 +169,11 @@ end
 -- `msmtp` with logging capability to that file. Otherwise, it logs to
 -- temporary file.
 --
--- @param filename string: path to the email message you would like to send
+---@param filename string: path to the email message you would like to send
 --
--- @return string: The log message provided by `msmtp`
+---@return string: The log message provided by `msmtp`
 --
--- @usage
+---@usage
 --   require('notmuch.send').sendmail('/tmp/my_new_email.eml')
 s.sendmail = function(filename)
   if not vim.loop.fs_stat(filename) then
@@ -237,7 +237,7 @@ end
 -- draft file will be stored in `tmp/` and a keymap (default `<C-c><C-c>`) to
 -- allow sending directly from within nvim
 --
--- @usage
+---@usage
 --   -- Typically you would just press `R` on a message in a thread
 --   require('notmuch.send').reply()
 s.reply = function()
@@ -314,9 +314,9 @@ end
 -- message headers and body. The mail content is stored in `/tmp/` so the user
 -- can come back to it later if needed.
 --
--- @param to string: recipient address (optionaal argument)
+---@param to string: recipient address (optionaal argument)
 --
--- @usage
+---@usage
 --   -- Typically you can run this with `:ComposeMail` or pressing `C`
 --   require('notmuch.send').compose()
 s.compose = function(to)

--- a/lua/notmuch/util.lua
+++ b/lua/notmuch/util.lua
@@ -90,10 +90,10 @@ end
 -- This function takes in a string and splits it into a table of strings based
 -- on some delimiter given by the caller, and returns the result table.
 --
--- @param s string: input string
--- @param delim string: delimiter string (can be char or more complex)
+---@param s string: input string
+---@param delim string: delimiter string (can be char or more complex)
 --
--- @returns out table: table of strings as split by the function given delim
+---@returns out table: table of strings as split by the function given delim
 u.split = function(s, delim)
   local out = {}
   local i = 1
@@ -109,10 +109,10 @@ end
 -- This function takes in a string and splits it into a table of strings based
 -- on some length given by the caller, and returns the result table.
 --
--- @param s string: input string
--- @param length integer: length integer
+---@param s string: input string
+---@param length integer: length integer
 --
--- @returns out table: table of strings as split by the function given length
+---@returns out table: table of strings as split by the function given length
 u.split_length = function(s, length)
   local out = {}
 
@@ -130,11 +130,11 @@ end
 -- function will prepend the header with special characters to signify its depth
 -- to the user in a user friendly way.
 --
--- @param buf int: id of the buffer containing the message header in question
--- @param lineno int: line number of the header which the user wants to indent
--- @param depth int: depth of the message in the reply chain of the thread
+---@param buf int: id of the buffer containing the message header in question
+---@param lineno int: line number of the header which the user wants to indent
+---@param depth int: depth of the message in the reply chain of the thread
 --
--- @usage
+---@usage
 -- -- See u.process_msgs_in_thread() for invocation example
 -- indent_depth(buf, lineno, msg.depth)
 local indent_depth = function(buf, lineno, depth)
@@ -152,7 +152,7 @@ end
 -- are modified for better readability and navigation through logical folds in
 -- Neovim.
 --
--- @param buf: The buffer id where the message content is located.
+---@param buf: The buffer id where the message content is located.
 --
 -- Behavior:
 -- - Identifies lines starting with "message{", extracting metadata.
@@ -229,9 +229,9 @@ end
 -- iteratively scanning each line backwards for the `id:` field. If used
 -- incorrectly or no id is found, a helpful message will indicate the same
 --
--- @returns id int: id of the email messageo
+---@returns id int: id of the email messageo
 --
--- @usage
+---@usage
 -- local id = require('notmuch.util').find_cursor_msg_id()
 -- -- Do something with the mail id (e.g. reply, tag, get attachments)
 u.find_cursor_msg_id = function()

--- a/lua/notmuch/util.lua
+++ b/lua/notmuch/util.lua
@@ -93,7 +93,7 @@ end
 ---@param s string: input string
 ---@param delim string: delimiter string (can be char or more complex)
 --
----@returns out table: table of strings as split by the function given delim
+---@return out table: table of strings as split by the function given delim
 u.split = function(s, delim)
   local out = {}
   local i = 1
@@ -112,7 +112,7 @@ end
 ---@param s string: input string
 ---@param length integer: length integer
 --
----@returns out table: table of strings as split by the function given length
+---@return out table: table of strings as split by the function given length
 u.split_length = function(s, length)
   local out = {}
 
@@ -229,7 +229,7 @@ end
 -- iteratively scanning each line backwards for the `id:` field. If used
 -- incorrectly or no id is found, a helpful message will indicate the same
 --
----@returns id int: id of the email messageo
+---@return id int: id of the email messageo
 --
 ---@usage
 -- local id = require('notmuch.util').find_cursor_msg_id()


### PR DESCRIPTION
A lot of lua annotations use two dashed instead of three, so Lua language servers don't recognize them or use them. Furthermore, there was a lot of `---@returns` instead of `---@return`.

Also, `@brief` isn't recognized by language servers (e.g. [see here](https://luals.github.io/wiki/annotations/#return)); usually they are just written after three dashed above the function, since they are documentation comments rather than annotations. I kept them for now, let me know if you're ok with removing them.