### PR TITLE
feat(thread): focus first message and configure auto-expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rule-based received attachment configuration for cache-backed open/view behavior:
   - `attachments.open`, `attachments.view`, `attachments.window`, and `attachments.cache_dir` provide the primary user-facing shorthand
   - `attach.incoming.open.rules` and `attach.incoming.view.rules` remain available as the advanced rule patch API
+- New `thread_auto_expand` config option for opening no message folds, the first fold, or all folds when entering a thread
 
 ### Changed
 
+- Thread buffers now place the cursor on the first message when opened or reused
 - Replaced deprecated `vim.loop` usage with `vim.uv` for Neovim libuv APIs.
 - Received attachment open/view actions now use deterministic cache extraction and rule registries instead of top-level handler callbacks.
 - Received attachment open, view, and save extraction now streams through temporary files and atomically publishes completed files.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ You can configure several global options to tailor the plugin's behavior:
 | `attach.incoming.*` | Advanced received attachment rule patch API | See below |
 | `render_html_body` | Render HTML email bodies inline using `w3m` (requires `w3m` installed)          | `false`                         |
 | `thread_view_mode` | Thread view mode: `"threaded"`, `"newest-first"`, or `"oldest-first"`        | `"threaded"`                   |
+| `thread_auto_expand` | Initial thread expansion: `"none"`, `"first"`, or `"all"` | `"none"` |
 | `drafts.folder` | Directory used for persistent compose/reply draft `.eml` files and JSON metadata | `stdpath("data")/notmuch.nvim/drafts` |
 | `drafts.delete_sent` | Delete the persistent draft after a successful send instead of marking it sent | `false` |
 | `drafts.show_sent_drafts` | Include sent drafts in draft pickers | `false` |
@@ -185,6 +186,7 @@ Example configuration in plugin manager (lazy.nvim):
             { name = "⌛ Overdue (+3d)", query = "tag:inbox and date:..3d" },
         },
         thread_view_mode = "threaded", -- OR "newest-first" OR "oldest-first"
+        thread_auto_expand = "none", -- OR "first" OR "all"
     },
 },
 ```

--- a/doc/notmuch.txt
+++ b/doc/notmuch.txt
@@ -525,6 +525,31 @@ option will be listed with its default value.
     })
 <
 
+*thread_auto_expand*
+  Controls which message folds are opened when entering a thread. The cursor
+  is always positioned on the first message, regardless of this setting.
+
+  - `"none"` (default):
+    Keep the current fold state.
+
+  - `"first"`:
+    Open the first message fold.
+
+  - `"all"`:
+    Open every message fold.
+
+  Invalid values produce a warning and fall back to `"none"`.
+
+  Default value:
+    `"none"`
+
+  Example: >
+
+    require('notmuch').setup({
+      thread_auto_expand = "first",
+    })
+<
+
 *suppress_deprecation_warning*
   Controls whether the plugin shows a warning notification when the installed
   version of notmuch uses the deprecated `notmuch_database_open` API (versions

--- a/lua/notmuch/config.lua
+++ b/lua/notmuch/config.lua
@@ -67,6 +67,7 @@ C.defaults = function()
     suppress_deprecation_warning = false, -- Used for API deprecation warning suppression
     render_html_body = false, -- True means prioritize displaying rendered HTML
     thread_view_mode = "threaded", -- "threaded" | "newest-first" | "oldest-first" - Thread view display mode
+    thread_auto_expand = "none", -- "none" | "first" | "all"
     drafts = {
       folder = vim.fs.joinpath(vim.fn.stdpath("data"), "notmuch.nvim", "drafts"),
       delete_sent = false,
@@ -189,6 +190,15 @@ C.setup = function(opts)
   end
 
   C.options = vim.tbl_deep_extend("force", defaults, options)
+
+  local valid_thread_auto_expand = { none = true, first = true, all = true }
+  if not valid_thread_auto_expand[C.options.thread_auto_expand] then
+    vim.notify(
+      "notmuch.nvim: invalid thread_auto_expand; falling back to 'none'",
+      vim.log.levels.WARN
+    )
+    C.options.thread_auto_expand = "none"
+  end
 
   -- If `attach.incoming.cache_dir` is set by user, expand it
   if C.options.attach and C.options.attach.incoming and C.options.attach.incoming.cache_dir then

--- a/lua/notmuch/init.lua
+++ b/lua/notmuch/init.lua
@@ -171,6 +171,29 @@ nm.reverse_sort_threads = function()
   vim.bo.modifiable = false
 end
 
+--- Position the cursor on the first message and apply the configured fold policy.
+local function apply_thread_open_behavior()
+  local messages = vim.b.notmuch_messages
+  local first_msg = messages and messages[1]
+  local fold_line = first_msg and first_msg.fold_line
+  local line_count = v.nvim_buf_line_count(0)
+  local has_valid_fold = type(fold_line) == "number" and fold_line >= 1 and fold_line <= line_count
+  local position = has_valid_fold and fold_line or 1
+
+  v.nvim_win_set_cursor(0, { position, 0 })
+
+  if not has_valid_fold then
+    return
+  end
+
+  local mode = config.options.thread_auto_expand
+  if mode == "first" and vim.fn.foldclosed(position) ~= -1 then
+    vim.cmd("normal! zo")
+  elseif mode == "all" then
+    vim.cmd("normal! zR")
+  end
+end
+
 --- Opens a thread in the mail view with all messages in the thread
 --
 -- This function fetches all the messages in the input thread's ID from the
@@ -202,6 +225,7 @@ nm.show_thread = function(s)
   local bufno = vim.fn.bufnr("thread:" .. threadid)
   if bufno ~= -1 then
     v.nvim_win_set_buf(0, bufno)
+    apply_thread_open_behavior()
     return true
   end
   local buf = v.nvim_create_buf(true, true)
@@ -221,11 +245,11 @@ nm.show_thread = function(s)
     "Hints: <Enter>: Toggle fold message | <Tab>: Next message | <S-Tab>: Prev message | q: Close | a: See attachment parts"
   v.nvim_buf_set_lines(buf, 0, 0, false, { hint_text, "" })
 
-  -- Place cursor at head of buffer and prepare display and disable modification
+  -- Prepare display, disable modification, and apply initial thread behavior
   v.nvim_buf_set_lines(buf, -2, -1, true, {})
-  v.nvim_win_set_cursor(0, { 1, 0 })
   vim.bo.filetype = "mail"
   vim.bo.modifiable = false
+  apply_thread_open_behavior()
 
   -- Set up cursor tracking for updating vim.b.notmuch_current
   require("notmuch.thread").setup_cursor_tracking(buf)

--- a/tests/specs/config_spec.lua
+++ b/tests/specs/config_spec.lua
@@ -46,6 +46,7 @@ return {
         H.eq(vim.fn.expand("~/custom-db"), config.options.notmuch_db_path)
         H.eq("User <user@localhost>", config.options.from)
         H.eq("background", config.options.sync.sync_mode)
+        H.eq("none", config.options.thread_auto_expand)
         H.eq(true, config.options.drafts.auto_open_attachment_window)
         H.eq("<F5>", config.options.keymaps.sendmail)
         H.eq("<C-g><C-a>", config.options.keymaps.attachment_window)
@@ -68,6 +69,34 @@ return {
         H.eq(true, config.setup({}))
         H.eq(false, config.options.drafts.auto_open_attachment_window)
       end)
+    end,
+  },
+  {
+    name = "config.setup validates thread auto-expand mode",
+    run = function()
+      local config = require("notmuch.config")
+      local notes = {}
+      local old_notify = vim.notify
+      vim.notify = function(msg, level)
+        table.insert(notes, { msg = msg, level = level })
+      end
+
+      with_mocked_notmuch_config({
+        ["database.path"] = "/tmp/notmuch-db",
+        ["user.name"] = "Tester",
+        ["user.primary_email"] = "tester@example.com",
+      }, function()
+        H.eq(true, config.setup({ thread_auto_expand = "all" }))
+        H.eq("all", config.options.thread_auto_expand)
+
+        H.eq(true, config.setup({ thread_auto_expand = "invalid" }))
+        H.eq("none", config.options.thread_auto_expand)
+      end)
+
+      H.eq(1, #notes)
+      H.contains(notes[1].msg, "invalid thread_auto_expand")
+      H.eq(vim.log.levels.WARN, notes[1].level)
+      vim.notify = old_notify
     end,
   },
   {

--- a/tests/specs/init_spec.lua
+++ b/tests/specs/init_spec.lua
@@ -153,7 +153,7 @@ return {
           called_id = threadid
           return { "Rendered header", "id:m1 {{{", "body", "}}}", "" }, {
             thread = { id = threadid, subject = "Rendered subject" },
-            messages = { { id = "m1", start_line = 3, end_line = 6 } },
+            messages = { { id = "m1", start_line = 3, fold_line = 4, end_line = 6 } },
           }
         end
         thread.setup_cursor_tracking = function(buf)
@@ -188,8 +188,97 @@ return {
         }, H.current_lines())
         H.eq("abc123", vim.b.notmuch_thread.id)
         H.eq("m1", vim.b.notmuch_messages[1].id)
+        H.eq(4, vim.api.nvim_win_get_cursor(0)[1])
       end)
 
+      thread.show_thread = old_show_thread
+      thread.setup_cursor_tracking = old_setup_cursor_tracking
+      if not ok then
+        error(err, 0)
+      end
+    end,
+  },
+  {
+    name = "show_thread applies configured fold expansion synchronously",
+    run = function()
+      local nm = require("notmuch")
+      local config = require("notmuch.config")
+      local thread = require("notmuch.thread")
+      local old_mode = config.options.thread_auto_expand
+      local old_show_thread = thread.show_thread
+      local old_setup_cursor_tracking = thread.setup_cursor_tracking
+
+      local ok, err = pcall(function()
+        thread.show_thread = function(threadid)
+          return {
+            "First sender",
+            "id:first {{{",
+            "First body",
+            "}}}",
+            "",
+            "Second sender",
+            "id:second {{{",
+            "Second body",
+            "}}}",
+            "",
+          }, {
+            thread = { id = threadid },
+            messages = {
+              { id = "first", start_line = 3, fold_line = 4, end_line = 6 },
+              { id = "second", start_line = 8, fold_line = 9, end_line = 11 },
+            },
+          }
+        end
+        thread.setup_cursor_tracking = function() end
+
+        for _, case in ipairs({
+          { mode = "none", first_closed = 4, second_closed = 9 },
+          { mode = "first", first_closed = -1, second_closed = 9 },
+          { mode = "all", first_closed = -1, second_closed = -1 },
+        }) do
+          config.options.thread_auto_expand = case.mode
+          nm.show_thread("thread:expand" .. case.mode)
+          H.eq(4, vim.api.nvim_win_get_cursor(0)[1])
+          H.eq(case.first_closed, vim.fn.foldclosed(4))
+          H.eq(case.second_closed, vim.fn.foldclosed(9))
+
+          H.eq(true, nm.show_thread("thread:expand" .. case.mode))
+          H.eq(4, vim.api.nvim_win_get_cursor(0)[1])
+          H.eq(case.first_closed, vim.fn.foldclosed(4))
+          H.eq(case.second_closed, vim.fn.foldclosed(9))
+        end
+      end)
+
+      config.options.thread_auto_expand = old_mode
+      thread.show_thread = old_show_thread
+      thread.setup_cursor_tracking = old_setup_cursor_tracking
+      if not ok then
+        error(err, 0)
+      end
+    end,
+  },
+  {
+    name = "show_thread falls back to line one without message metadata",
+    run = function()
+      local nm = require("notmuch")
+      local config = require("notmuch.config")
+      local thread = require("notmuch.thread")
+      local old_mode = config.options.thread_auto_expand
+      local old_show_thread = thread.show_thread
+      local old_setup_cursor_tracking = thread.setup_cursor_tracking
+
+      local ok, err = pcall(function()
+        config.options.thread_auto_expand = "first"
+        thread.show_thread = function()
+          return { "Thread not found or empty" }, {}
+        end
+        thread.setup_cursor_tracking = function() end
+
+        H.eq(nil, nm.show_thread("thread:missing"))
+        H.eq(1, vim.api.nvim_win_get_cursor(0)[1])
+      end)
+
+      config.options.thread_auto_expand = old_mode
       thread.show_thread = old_show_thread
       thread.setup_cursor_tracking = old_setup_cursor_tracking
       if not ok then
@@ -204,8 +293,11 @@ return {
       local id = H.first_thread_id("tag:inbox")
       nm.show_thread("thread:" .. id)
       local first = vim.api.nvim_get_current_buf()
+      local first_fold_line = vim.b.notmuch_messages[1].fold_line
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
       nm.show_thread("thread:" .. id)
       H.eq(first, vim.api.nvim_get_current_buf())
+      H.eq(first_fold_line, vim.api.nvim_win_get_cursor(0)[1])
 
       local buf = vim.api.nvim_create_buf(true, true)
       vim.api.nvim_win_set_buf(0, buf)


### PR DESCRIPTION
# feat(thread): focus first message and configure auto-expansion

## Summary

This PR builds on and supersedes #49, originally contributed by @antinomie8.

It preserves the original goal of improving thread navigation while making the behavior safer, configurable, and consistent when reopening existing thread buffers.

When entering a thread, the cursor is now positioned on the first message rather than the hints at the top of the buffer.

## Configuration

A new `thread_auto_expand` option controls which message folds are opened:

```lua
require("notmuch").setup({
  thread_auto_expand = "none", -- "none" | "first" | "all"
})
```

The available modes are:

- `"none"` (default): focus the first message without changing the existing fold state.
- `"first"`: focus and unfold the first message.
- `"all"`: focus the first message and unfold every message.

Invalid values produce a warning and fall back to `"none"`.

## Improvements over #49

- Uses the first message’s `fold_line` metadata with a safe line-1 fallback instead of hard-coding line 4.
- Replaces the single-message special case with configurable `"none"`, `"first"`, and `"all"` expansion modes.
- Applies cursor and fold behavior synchronously to both new and reused thread buffers, avoiding cross-buffer races.
- Adds validation, test coverage, and documentation for the new behavior.