### PR TITLE
fix: address reported mail and attachment security issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Received attachment open, view, and save extraction now streams through temporary files and atomically publishes completed files.
 - The default received attachment opener now prefers `vim.ui.open()` when available and falls back to the OS opener command.
 
+### Fixed
+
+- Prevented shell injection through untrusted message IDs when listing received-message MIME parts.
+
 ### Removed
 
 - Removed the unused `:FollowPatch` command and `U` URL-extraction mapping, including the optional `:YTerm`/`urlextract` integration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Removed the unused `:FollowPatch` command and `U` URL-extraction mapping, including the optional `:YTerm`/`urlextract` integration.
 - Removed the unused internal `notmuch.float` module. Floating attachment viewing is handled directly by the attachment viewer.
 - Removed top-level received attachment `open_handler` and `view_handler` configuration callbacks in favor of `attachments.open`/`attachments.view` rules, with `attach.incoming.*` available for advanced patching.
 - Removed the legacy `lua/notmuch/handlers.lua` callback implementation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Restricted received-attachment cache directories to private `0700` permissions.
 - Created outgoing message and MIME-body temporary files with private `0600` permissions.
 - Prevented shell injection through untrusted message IDs when listing received-message MIME parts.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Created outgoing message and MIME-body temporary files with private `0600` permissions.
 - Prevented shell injection through untrusted message IDs when listing received-message MIME parts.
 
 ### Removed

--- a/doc/notmuch.txt
+++ b/doc/notmuch.txt
@@ -81,10 +81,6 @@ Here is a non-comprehensive list of features of notmuch.nvim:
 - Tagging threads/messages
   - Add, remove, or toggle one or more tags at once
   - Inspect all tags pertinent to thread/msg
-- GitHub compatibility features
-  - Follow pull request patches
-- Extract URLs with a script
-
 ------------------------------------------------------------------------------
 REQUIREMENTS                                             *notmuch-requirements*
 
@@ -916,7 +912,6 @@ plugin's project codebase.
 
   - **attach/parts.lua**:
     - Handles received-message MIME part listing/opening/viewing/saving.
-    - Supports extracting URLs from messages and following GitHub patch links.
 
   - **attach/incoming/**:
     - Rule-based received attachment subsystem.

--- a/ftplugin/mail.lua
+++ b/ftplugin/mail.lua
@@ -27,14 +27,6 @@ if vim.startswith(vim.fs.basename(vim.api.nvim_buf_get_name(0)), "thread:") then
     force = true,
   })
 
-  vim.api.nvim_buf_create_user_command(0, "FollowPatch", function()
-    local line = vim.api.nvim_win_get_cursor(0)[1]
-    parts.follow_github_patch(line)
-  end, {
-    force = true,
-  })
-
-  vim.keymap.set("n", "U", parts.get_urls_from_cursor_msg, { buffer = true })
   vim.keymap.set("n", "<Tab>", "zj", { buffer = true, silent = true })
   vim.keymap.set("n", "<S-Tab>", "zk", { buffer = true, silent = true })
   vim.keymap.set("n", "<Enter>", "za", { buffer = true, silent = true })

--- a/lua/notmuch/attach/incoming/extractor.lua
+++ b/lua/notmuch/attach/incoming/extractor.lua
@@ -46,6 +46,24 @@ local function sanitize_component(value)
   return value
 end
 
+local PRIVATE_DIR_MODE = 448 -- 0700
+
+local function ensure_private_cache_dir(dir)
+  if vim.fn.mkdir(dir, "p", PRIVATE_DIR_MODE) == 0 and vim.fn.isdirectory(dir) == 0 then
+    return nil, "failed to create cache directory: " .. dir
+  end
+
+  -- Unix permission bits do not provide the same guarantees on Windows.
+  if vim.fn.has("win32") == 0 then
+    local secured, chmod_err = vim.uv.fs_chmod(dir, PRIVATE_DIR_MODE)
+    if not secured then
+      return nil, "failed to secure cache directory: " .. tostring(chmod_err)
+    end
+  end
+
+  return true
+end
+
 local function ensure_parent_dir(path)
   local dir = vim.fn.fnamemodify(path, ":h")
   if vim.fn.mkdir(dir, "p") == 0 and vim.fn.isdirectory(dir) == 0 then
@@ -132,6 +150,14 @@ function E.extract_to_cache(message_id, part, opts)
   local path, err = E.cache_path(message_id, part, opts)
   if not path then
     return nil, err
+  end
+
+  -- Cache paths have the form:
+  -- <cache-root>/<message-id-hash>/<part-id>-<filename>
+  local cache_parent = vim.fn.fnamemodify(path, ":h")
+  local secured, secure_err = ensure_private_cache_dir(cache_parent)
+  if not secured then
+    return nil, secure_err
   end
 
   if not opts.force and vim.fn.filereadable(path) == 1 then

--- a/lua/notmuch/attach/parts.lua
+++ b/lua/notmuch/attach/parts.lua
@@ -13,17 +13,6 @@ local thread = require("notmuch.thread")
 -- PRIVATE FUNCTIONS
 --------------------------------------------------------------------------------
 
-local function show_github_patch(link)
-  local buf = v.nvim_create_buf(true, true)
-  v.nvim_buf_set_name(buf, link)
-  v.nvim_win_set_buf(0, buf)
-  v.nvim_command("silent 0read! curl -Ls " .. link)
-  v.nvim_win_set_cursor(0, { 1, 0 })
-  v.nvim_buf_set_lines(buf, -2, -1, true, {})
-  vim.bo.filetype = "gitsendemail"
-  vim.bo.modifiable = false
-end
-
 --- Formats a list of MIME parts into display lines for the attachment buffer.
 --
 -- Creates a table of formatted strings with aligned columns showing:
@@ -349,32 +338,6 @@ function P.view_attachment_part()
   local id = string.match(v.nvim_buf_get_name(0), "id:%C+")
   local rendered = require("notmuch.attach.incoming").view_part(part, id)
   return rendered
-end
-
-function P.get_urls_from_cursor_msg()
-  if vim.fn.exists(":YTerm") == 0 then
-    print("Can't launch URL selector (:YTerm command not found)")
-    return nil
-  end
-  local id = thread.get_current_message_id()
-  if id == nil then
-    return nil
-  end
-  v.nvim_command('YTerm "notmuch show id:' .. id .. ' | urlextract"')
-end
-
-function P.follow_github_patch(line)
-  -- https://github.com/neomutt/neomutt/pull/2774.patch
-  local link = string.match(line, "http[s]://github%.com/.+/.+/pull/%d+%.patch")
-  if link == nil then
-    return nil
-  end
-  local bufno = vim.fn.bufnr(link)
-  if bufno ~= -1 then
-    v.nvim_win_set_buf(0, bufno)
-  else
-    show_github_patch(link)
-  end
 end
 
 return P

--- a/lua/notmuch/attach/parts.lua
+++ b/lua/notmuch/attach/parts.lua
@@ -180,18 +180,42 @@ function P.get_attachments_from_cursor_msg()
     return nil
   end
 
-  -- Create new attachment listing buffer (`notmuch-attach`)
-  v.nvim_command("belowright 8new")
-  v.nvim_buf_set_name(0, "id:" .. id)
-  vim.bo.buftype = "nofile"
+  -- Run notmuch show to get the JSON output in a safe process
+  local process = vim
+    .system({
+      "notmuch",
+      "show",
+      "--exclude=false",
+      "--part=0",
+      "--format=json",
+      "id:" .. id,
+    }, { text = true })
+    :wait()
 
-  -- Get all MIME parts from `msg` in JSON format
-  local result = vim.json.decode(
-    vim.fn.system("notmuch show --exclude=false --part=0 --format=json 'id:" .. id .. "'")
-  )
+  -- Report error if `notmuch show` failed
+  if process.code ~= 0 then
+    vim.notify(
+      "Failed to inspect message attachments: " .. (process.stderr or "notmuch show failed"),
+      vim.log.levels.ERROR
+    )
+    return nil
+  end
+
+  -- Decode json into lua variable
+  local ok, result = pcall(vim.json.decode, process.stdout or "")
+  if not ok then
+    vim.notify("Failed to parse message attachment data", vim.log.levels.ERROR)
+    return nil
+  end
+
   local parts_list = {}
   parse_mime_tree(result["body"][1], parts_list)
   local lines = format_part_line(parts_list)
+
+  -- Create new attachment listing buffer (`notmuch-attach`) only after loading succeeds
+  v.nvim_command("belowright 8new")
+  v.nvim_buf_set_name(0, "id:" .. id)
+  vim.bo.buftype = "nofile"
 
   -- Save MIME parts list to buffer local variable
   v.nvim_buf_set_var(0, "mime_parts_list", parts_list)

--- a/lua/notmuch/send.lua
+++ b/lua/notmuch/send.lua
@@ -32,6 +32,28 @@ local confirm_sendmail = function()
   end
 end
 
+---Create tempfile for the outgoing mail to be sent with private permissions
+---
+---@param label string Prefix to the temp file name
+---@return string|nil path Path to the created temp file, or nil if error
+---@return string|nil err Error message, or nil if success
+local function create_private_tempfile(label)
+  local template = vim.fn.tempname() .. "-" .. label .. "-XXXXXX"
+  local fd, path_or_err = vim.uv.fs_mkstemp(template)
+
+  if not fd then
+    return nil, "Failed to create temporary file: " .. tostring(path_or_err)
+  end
+
+  local closed, close_err = vim.uv.fs_close(fd)
+  if not closed then
+    vim.uv.fs_unlink(path_or_err)
+    return nil, "Failed to close temporary file: " .. tostring(close_err)
+  end
+
+  return path_or_err
+end
+
 local build_plain_msg_file = function(buf, output_filename)
   local main_lines = v.nvim_buf_get_lines(buf, 0, -1, false)
   local attributes, msg = m.get_msg_attributes(main_lines)
@@ -56,7 +78,12 @@ end
 local build_mime_msg_file = function(buf, attachment_paths, output_filename)
   local main_lines = v.nvim_buf_get_lines(buf, 0, -1, false)
   local attributes, msg = m.get_msg_attributes(main_lines)
-  local body_filename = vim.fn.tempname() .. "-notmuch-body.txt"
+
+  local body_filename, temp_err = create_private_tempfile("notmuch-body")
+  if not body_filename then
+    vim.notify(temp_err, vim.log.levels.ERROR)
+    return false
+  end
 
   local ok, err = pcall(function()
     local attachments = m.create_mime_attachments(attachment_paths)
@@ -101,8 +128,13 @@ local build_mime_msg_file = function(buf, attachment_paths, output_filename)
 end
 
 local build_send_file = function(buf, attachment_paths)
-  local send_filename = vim.fn.tempname() .. "-notmuch-send.eml"
   local ok
+
+  local send_filename, temp_err = create_private_tempfile("notmuch-send")
+  if not send_filename then
+    vim.notify(temp_err, vim.log.levels.ERROR)
+    return nil
+  end
 
   if #attachment_paths == 0 then
     ok = build_plain_msg_file(buf, send_filename)

--- a/tests/specs/attach_incoming_extractor_spec.lua
+++ b/tests/specs/attach_incoming_extractor_spec.lua
@@ -7,6 +7,11 @@ local function read_file(path)
   return data
 end
 
+local function permission_mode(path)
+  local stat = vim.uv.fs_stat(path)
+  return stat and bit.band(stat.mode, 511) or nil
+end
+
 local function with_mocked_system(result, fn)
   local old_system = vim.system
   local calls = {}
@@ -256,6 +261,96 @@ return {
     end,
   },
   {
+    name = "attach.incoming.extractor.extract_to_cache creates private directories and files",
+    run = function()
+      local extractor = require("notmuch.attach.incoming.extractor")
+      local cache_dir = vim.fs.joinpath(H.tmpdir(), "nested", "cache")
+      local part = { id = 2, filename = "doc.txt", content_type = "text/plain" }
+
+      with_mocked_system({ code = 0, stdout = "cached", stderr = "" }, function()
+        local path, err = extractor.extract_to_cache("msg1", part, { cache_dir = cache_dir })
+
+        H.ok(path)
+        H.eq(nil, err)
+        H.eq("cached", read_file(path))
+        if vim.fn.has("win32") == 0 then
+          H.eq(448, permission_mode(vim.fn.fnamemodify(path, ":h")))
+          H.eq(384, permission_mode(path))
+        end
+      end)
+    end,
+  },
+  {
+    name = "attach.incoming.extractor.extract_to_cache repairs existing cache directory permissions",
+    run = function()
+      if vim.fn.has("win32") == 1 then
+        return
+      end
+
+      local extractor = require("notmuch.attach.incoming.extractor")
+      local dir = H.tmpdir()
+      local part = { id = 2, filename = "doc.txt", content_type = "text/plain" }
+      local expected = assert(extractor.cache_path("msg1", part, { cache_dir = dir }))
+      local cache_parent = vim.fn.fnamemodify(expected, ":h")
+      vim.fn.mkdir(cache_parent, "p")
+      assert(vim.uv.fs_chmod(cache_parent, 493)) -- 0755
+      H.write_file(expected, "cached")
+
+      local old_system = vim.system
+      vim.system = function()
+        error("vim.system should not be called for cached extraction")
+      end
+
+      local ok, err = pcall(function()
+        local path, extract_err = extractor.extract_to_cache("msg1", part, { cache_dir = dir })
+        H.eq(expected, path)
+        H.eq(nil, extract_err)
+        H.eq(448, permission_mode(cache_parent))
+      end)
+
+      vim.system = old_system
+      if not ok then
+        error(err, 0)
+      end
+    end,
+  },
+  {
+    name = "attach.incoming.extractor.extract_to_cache reports permission hardening failures",
+    run = function()
+      if vim.fn.has("win32") == 1 then
+        return
+      end
+
+      local extractor = require("notmuch.attach.incoming.extractor")
+      local dir = H.tmpdir()
+      local part = { id = 2, filename = "doc.txt", content_type = "text/plain" }
+      local old_chmod = vim.uv.fs_chmod
+      local old_system = vim.system
+      local system_called = false
+
+      vim.uv.fs_chmod = function()
+        return nil, "permission denied"
+      end
+      vim.system = function()
+        system_called = true
+        error("vim.system should not run when cache permissions cannot be secured")
+      end
+
+      local ok, test_err = pcall(function()
+        local path, err = extractor.extract_to_cache("msg1", part, { cache_dir = dir })
+        H.eq(nil, path)
+        H.contains(err, "permission denied")
+        H.eq(false, system_called)
+      end)
+
+      vim.uv.fs_chmod = old_chmod
+      vim.system = old_system
+      if not ok then
+        error(test_err, 0)
+      end
+    end,
+  },
+  {
     name = "attach.incoming.extractor.extract_to_cache reuses existing cached files",
     run = function()
       local extractor = require("notmuch.attach.incoming.extractor")
@@ -312,6 +407,9 @@ return {
     run = function()
       local extractor = require("notmuch.attach.incoming.extractor")
       local dir = H.tmpdir()
+      if vim.fn.has("win32") == 0 then
+        assert(vim.uv.fs_chmod(dir, 493)) -- 0755
+      end
       local out = vim.fs.joinpath(dir, "saved.txt")
       local saved, err = extractor.save_to_path("msg1", nil, out)
 
@@ -331,6 +429,9 @@ return {
           "id:msg1",
         }, calls[1].cmd)
         H.eq("saved body", read_file(out))
+        if vim.fn.has("win32") == 0 then
+          H.eq(493, permission_mode(dir), "save_to_path must not chmod user directories")
+        end
       end)
     end,
   },

--- a/tests/specs/attach_parts_spec.lua
+++ b/tests/specs/attach_parts_spec.lua
@@ -31,6 +31,16 @@ local function attachment_buf(parts, name)
   return buf
 end
 
+local function with_system(mock, fn)
+  local old_system = vim.system
+  vim.system = mock
+  local ok, err = pcall(fn)
+  vim.system = old_system
+  if not ok then
+    error(err, 0)
+  end
+end
+
 local function with_save_extractor(mock, fn)
   local extractor = require("notmuch.attach.incoming.extractor")
   local old_save_to_path = extractor.save_to_path
@@ -57,8 +67,7 @@ return {
     name = "attach.parts.get_attachments_from_cursor_msg creates formatted attachment list buffer",
     run = function()
       local attach = require("notmuch.attach.parts")
-      local old_system = vim.fn.system
-      local command
+      local command, system_opts
       local json = {
         body = {
           {
@@ -89,42 +98,138 @@ return {
           },
         },
       }
-      vim.fn.system = function(cmd)
+      with_system(function(cmd, opts)
         command = cmd
-        return vim.json.encode(json)
-      end
+        system_opts = opts
+        return {
+          wait = function()
+            return { code = 0, stdout = vim.json.encode(json), stderr = "" }
+          end,
+        }
+      end, function()
+        with_current_message_id("msg1", function()
+          attach.get_attachments_from_cursor_msg()
+        end)
 
-      with_current_message_id("msg1", function()
-        attach.get_attachments_from_cursor_msg()
+        H.eq("id:msg1", vim.api.nvim_buf_get_name(0):match("([^/]+)$"))
+        H.eq("nofile", vim.bo.buftype)
+        H.eq("notmuch-attach", vim.bo.filetype)
+        H.eq(false, vim.bo.modifiable)
+        H.same({
+          "notmuch",
+          "show",
+          "--exclude=false",
+          "--part=0",
+          "--format=json",
+          "id:msg1",
+        }, command)
+        H.same({ text = true }, system_opts)
+
+        local parts = vim.api.nvim_buf_get_var(0, "mime_parts_list")
+        H.eq(4, #parts)
+        H.eq(1, parts[1].id)
+        H.eq("inline", parts[1].disposition)
+        H.eq(3, parts[2].id)
+        H.eq("text/html", parts[2].content_type)
+        H.eq(4, parts[3].id)
+        H.eq("doc.pdf", parts[3].filename)
+        H.eq(5, parts[4].id)
+        H.eq("attachment", parts[4].disposition)
+
+        local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+        H.contains(lines, "Hints: v: View")
+        H.contains(lines, "?  ID")
+        H.contains(lines, "I  1     body (text/plain)")
+        H.contains(lines, "I  3     body (text/html)")
+        H.contains(lines, "A  4     doc.pdf")
+        H.contains(lines, "A  5     body (image/png)")
+
+        vim.api.nvim_buf_delete(0, { force = true })
+      end)
+    end,
+  },
+  {
+    name = "attach.parts.get_attachments_from_cursor_msg keeps untrusted message ids in one argv element",
+    run = function()
+      local attach = require("notmuch.attach.parts")
+      local malicious_id = [["msg';touch${IFS}/tmp/notmuch-nvim-poc;'"@example.com]]
+      local command
+      local json = {
+        body = {
+          { id = 1, ["content-type"] = "text/plain", ["content-length"] = 4 },
+        },
+      }
+
+      with_system(function(cmd)
+        command = cmd
+        return {
+          wait = function()
+            return { code = 0, stdout = vim.json.encode(json), stderr = "" }
+          end,
+        }
+      end, function()
+        with_current_message_id(malicious_id, function()
+          attach.get_attachments_from_cursor_msg()
+        end)
       end)
 
-      H.eq("id:msg1", vim.api.nvim_buf_get_name(0):match("([^/]+)$"))
-      H.eq("nofile", vim.bo.buftype)
-      H.eq("notmuch-attach", vim.bo.filetype)
-      H.eq(false, vim.bo.modifiable)
-      H.eq("notmuch show --exclude=false --part=0 --format=json 'id:msg1'", command)
-
-      local parts = vim.api.nvim_buf_get_var(0, "mime_parts_list")
-      H.eq(4, #parts)
-      H.eq(1, parts[1].id)
-      H.eq("inline", parts[1].disposition)
-      H.eq(3, parts[2].id)
-      H.eq("text/html", parts[2].content_type)
-      H.eq(4, parts[3].id)
-      H.eq("doc.pdf", parts[3].filename)
-      H.eq(5, parts[4].id)
-      H.eq("attachment", parts[4].disposition)
-
-      local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
-      H.contains(lines, "Hints: v: View")
-      H.contains(lines, "?  ID")
-      H.contains(lines, "I  1     body (text/plain)")
-      H.contains(lines, "I  3     body (text/html)")
-      H.contains(lines, "A  4     doc.pdf")
-      H.contains(lines, "A  5     body (image/png)")
-
-      vim.fn.system = old_system
+      H.eq(6, #command)
+      H.eq("id:" .. malicious_id, command[6])
       vim.api.nvim_buf_delete(0, { force = true })
+    end,
+  },
+  {
+    name = "attach.parts.get_attachments_from_cursor_msg reports process and JSON failures",
+    run = function()
+      local attach = require("notmuch.attach.parts")
+      local start_buf = vim.api.nvim_get_current_buf()
+      local start_wins = #vim.api.nvim_list_wins()
+      local old_notify = vim.notify
+      local notes = {}
+      vim.notify = function(msg, level)
+        notes[#notes + 1] = { msg = msg, level = level }
+      end
+
+      local ok, err = pcall(function()
+        with_system(function()
+          return {
+            wait = function()
+              return { code = 1, stdout = "", stderr = "notmuch failed" }
+            end,
+          }
+        end, function()
+          with_current_message_id("process-failure", function()
+            H.eq(nil, attach.get_attachments_from_cursor_msg())
+          end)
+        end)
+
+        H.contains(notes[#notes].msg, "notmuch failed")
+        H.eq(vim.log.levels.ERROR, notes[#notes].level)
+        H.eq(start_buf, vim.api.nvim_get_current_buf())
+        H.eq(start_wins, #vim.api.nvim_list_wins())
+
+        with_system(function()
+          return {
+            wait = function()
+              return { code = 0, stdout = "not-json", stderr = "" }
+            end,
+          }
+        end, function()
+          with_current_message_id("json-failure", function()
+            H.eq(nil, attach.get_attachments_from_cursor_msg())
+          end)
+        end)
+
+        H.contains(notes[#notes].msg, "Failed to parse")
+        H.eq(vim.log.levels.ERROR, notes[#notes].level)
+        H.eq(start_buf, vim.api.nvim_get_current_buf())
+        H.eq(start_wins, #vim.api.nvim_list_wins())
+      end)
+
+      vim.notify = old_notify
+      if not ok then
+        error(err, 0)
+      end
     end,
   },
   {

--- a/tests/specs/ftplugin_spec.lua
+++ b/tests/specs/ftplugin_spec.lua
@@ -307,6 +307,8 @@ return {
       vim.cmd("runtime ftplugin/mail.lua")
       H.eq("marker", vim.wo.foldmethod)
       H.eq(0, vim.wo.foldlevel)
+      H.eq(nil, vim.api.nvim_buf_get_commands(thread, {}).FollowPatch)
+      H.eq(nil, map_rhs("n", "U", thread))
       H.eq("za", map_rhs("n", "<CR>", thread))
       H.eq("zj", map_rhs("n", "<Tab>", thread))
       H.eq("zk", map_rhs("n", "<S-Tab>", thread))

--- a/tests/specs/send_spec.lua
+++ b/tests/specs/send_spec.lua
@@ -9,6 +9,32 @@ local function map_callback(mode, lhs, buf)
   end
 end
 
+local function file_mode(path)
+  local stat = vim.uv.fs_stat(path)
+  return stat and bit.band(stat.mode, 511) or nil
+end
+
+local function assert_private_file(path)
+  if vim.fn.has("win32") == 0 then
+    H.eq(384, file_mode(path), "expected private file permissions (0600)")
+  end
+end
+
+local function with_mime_builder_spy(spy, fn)
+  local mime = require("notmuch.mime")
+  local old_make_mime_msg = mime.make_mime_msg
+  mime.make_mime_msg = function(mime_table)
+    spy(mime_table)
+    return old_make_mime_msg(mime_table)
+  end
+
+  local ok, err = pcall(fn)
+  mime.make_mime_msg = old_make_mime_msg
+  if not ok then
+    error(err, 0)
+  end
+end
+
 local function with_send_env(fn)
   local send = require("notmuch.send")
   local config = require("notmuch.config")
@@ -179,7 +205,8 @@ return {
         map_callback("n", config.options.keymaps.sendmail, main_buf)()
 
         H.eq(1, #state.sent)
-        H.matches(state.sent[1], "%-notmuch%-send%.eml$")
+        H.matches(state.sent[1], "%-notmuch%-send%-%w%w%w%w%w%w$")
+        assert_private_file(state.sent[1])
         local sent_lines = vim.fn.readfile(state.sent[1])
         H.contains(sent_lines, "From: Sender Name <sender@example.com>")
         H.contains(sent_lines, "To: plain@example.com")
@@ -204,6 +231,8 @@ return {
     run = function()
       with_send_env(function(state, send, config)
         local attachment = H.write_file(state.dir .. "/attachment.txt", "attached text\n")
+        local body_filename
+        local body_mode
         send.sendmail = function(path)
           table.insert(state.sent, path)
           return true
@@ -212,28 +241,42 @@ return {
           return 1
         end
 
-        send.compose("mime@example.com")
-        local main_buf = vim.api.nvim_get_current_buf()
-        vim.api.nvim_buf_set_lines(main_buf, 5, -1, false, { "Hello MIME body" })
+        with_mime_builder_spy(function(mime_table)
+          if mime_table.mime then
+            body_filename = mime_table.mime[1].file
+            body_mode = file_mode(body_filename)
+          end
+        end, function()
+          send.compose("mime@example.com")
+          local main_buf = vim.api.nvim_get_current_buf()
+          vim.api.nvim_buf_set_lines(main_buf, 5, -1, false, { "Hello MIME body" })
 
-        map_callback("n", config.options.keymaps.attachment_window, main_buf)()
-        local attach_buf = vim.api.nvim_get_current_buf()
-        vim.api.nvim_buf_set_lines(attach_buf, 0, -1, false, { attachment })
-        vim.api.nvim_set_current_buf(main_buf)
+          map_callback("n", config.options.keymaps.attachment_window, main_buf)()
+          local attach_buf = vim.api.nvim_get_current_buf()
+          vim.api.nvim_buf_set_lines(attach_buf, 0, -1, false, { attachment })
+          vim.api.nvim_set_current_buf(main_buf)
 
-        map_callback("n", config.options.keymaps.sendmail, main_buf)()
+          map_callback("n", config.options.keymaps.sendmail, main_buf)()
 
-        H.eq(1, #state.sent)
-        H.matches(state.sent[1], "%-notmuch%-send%.eml$")
-        local text = table.concat(vim.fn.readfile(state.sent[1]), "\n")
-        H.contains(text, "From: Sender Name <sender@example.com>")
-        H.contains(text, "To: mime@example.com")
-        H.contains(text, "Content-Type: multipart/mixed")
-        H.contains(text, 'Content-Disposition: attachment; filename="attachment.txt"')
-        H.contains(text, "Hello MIME body")
-        local metadata =
-          require("notmuch.draft").read_metadata(vim.b[main_buf].notmuch_draft_json_path)
-        H.same({ attachment }, metadata.attachments)
+          H.eq(1, #state.sent)
+          H.matches(state.sent[1], "%-notmuch%-send%-%w%w%w%w%w%w$")
+          assert_private_file(state.sent[1])
+          local text = table.concat(vim.fn.readfile(state.sent[1]), "\n")
+          H.contains(text, "From: Sender Name <sender@example.com>")
+          H.contains(text, "To: mime@example.com")
+          H.contains(text, "Content-Type: multipart/mixed")
+          H.contains(text, 'Content-Disposition: attachment; filename="attachment.txt"')
+          H.contains(text, "Hello MIME body")
+          local metadata =
+            require("notmuch.draft").read_metadata(vim.b[main_buf].notmuch_draft_json_path)
+          H.same({ attachment }, metadata.attachments)
+        end)
+
+        H.ok(body_filename, "expected MIME body temporary file")
+        if vim.fn.has("win32") == 0 then
+          H.eq(384, body_mode, "expected private MIME body permissions (0600)")
+        end
+        H.eq(nil, vim.uv.fs_stat(body_filename), "MIME body temporary file was not deleted")
       end)
     end,
   },
@@ -349,7 +392,8 @@ return {
           "Plain reply body",
         })
         map_callback("n", config.options.keymaps.sendmail, plain_buf)()
-        H.matches(state.sent[#state.sent], "%-notmuch%-send%.eml$")
+        H.matches(state.sent[#state.sent], "%-notmuch%-send%-%w%w%w%w%w%w$")
+        assert_private_file(state.sent[#state.sent])
         H.contains(vim.fn.readfile(state.sent[#state.sent]), "MIME-Version: 1.0")
 
         thread.get_current_message_id = function()
@@ -370,7 +414,8 @@ return {
         vim.api.nvim_buf_set_lines(attach_buf, 0, -1, false, { attachment })
         vim.api.nvim_set_current_buf(mime_buf)
         map_callback("n", config.options.keymaps.sendmail, mime_buf)()
-        H.matches(state.sent[#state.sent], "%-notmuch%-send%.eml$")
+        H.matches(state.sent[#state.sent], "%-notmuch%-send%-%w%w%w%w%w%w$")
+        assert_private_file(state.sent[#state.sent])
         local text = table.concat(vim.fn.readfile(state.sent[#state.sent]), "\n")
         H.contains(text, "Content-Type: multipart/mixed")
         H.contains(text, 'Content-Disposition: attachment; filename="reply-attachment.txt"')


### PR DESCRIPTION
## Summary

This PR addresses the five security reports opened against Notmuch.nvim.

It removes two obsolete shell-based features, replaces unsafe shell command
construction with argv-based process execution, and hardens temporary-file and
attachment-cache permissions.

## Issue mapping

### Closes #61 — Command injection via email body

Removed the obsolete `:FollowPatch` command and its shell-based GitHub patch
retrieval implementation.

Fixed by [`b9979ec`](https://github.com/yousefakbar/notmuch.nvim/commit/b9979ecca2284c2574c7a55f0051314aab5d4089).

### Closes #62 — Shell injection via message-ID

Replaced the shell-string invocation of `notmuch show` with argv-based
`vim.system()` execution. The untrusted message ID is now passed as one process
argument.

Regression tests cover message IDs containing shell metacharacters, process
failures, and malformed JSON output.

Fixed by [`602c82b`](https://github.com/yousefakbar/notmuch.nvim/commit/602c82bfe15fa77544c5b1f4a6d907804b1a52a0).

### Closes #63 — Shell injection through `:YTerm`

Removed the obsolete `:YTerm`/`urlextract` integration and its associated `U`
mapping.

Fixed by [`b9979ec`](https://github.com/yousefakbar/notmuch.nvim/commit/b9979ecca2284c2574c7a55f0051314aab5d4089).

### Closes #64 — Outgoing email temporary-file permissions

Outgoing message and MIME-body temporary files are now created atomically with
`vim.uv.fs_mkstemp()`, giving them private `0600` permissions on Unix.

Although Neovim already places `tempname()` results inside a private `0700`
session directory, this change provides defense in depth for the files
themselves.

Fixed by [`9c69b1b`](https://github.com/yousefakbar/notmuch.nvim/commit/9c69b1b0b4b89c8f83dc5e48320bf636adf536b0).

### Closes #65 — Attachment cache-directory permissions

Received-attachment message cache directories are now created with `0700`
permissions. Existing permissive cache directories are repaired before cached
files are reused.

The generic save path remains unchanged, so the plugin does not modify
permissions on user-selected directories such as `~/Downloads`.

Fixed by [`0ab17f9`](https://github.com/yousefakbar/notmuch.nvim/commit/0ab17f9a4e85c8d2fa0d9b33f442eb186771709a).

## Validation

- `make test` — 212 tests passed
- `make lint` — passed
- `git diff --check` — passed
